### PR TITLE
Remove RKH websites from code

### DIFF
--- a/importer/management/commands/make_footer_links.py
+++ b/importer/management/commands/make_footer_links.py
@@ -3,7 +3,7 @@ import sys
 from django.core.management.base import BaseCommand
 from wagtail.core.models import Page
 from cms.core.models import CoreSettings, UpperFooterLinks, LowerFooterLinks
-
+from importer.websites import STAGING
 
 class Command(BaseCommand):
     help = 'Creates the footer links'
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         contact_us = None
         complaints = None
         jobs = None
-        transparency_legal = 'https://staging.nhsei.rkh.co.uk/transparency-and-legal/'
+        transparency_legal = STAGING + 'transparency-and-legal/'
         statistics = 'https://www.england.nhs.uk/statistics'
 
         terms_and_conditions = None

--- a/importer/management/commands/make_home_page.py
+++ b/importer/management/commands/make_home_page.py
@@ -6,7 +6,7 @@ from django.core.files.images import ImageFile
 from django.core.management.base import BaseCommand
 from wagtail.core.models import Collection
 from wagtail.images.models import Image
-
+from importer.webpages import STAGING
 
 class Command(BaseCommand):
     help = 'Creates the home page content'
@@ -41,28 +41,28 @@ class Command(BaseCommand):
                     'heading_level': '3',
                     'promos': [
                         {
-                            'url': 'https://staging.nhsei.rkh.co.uk/publication/nhs-england-improvement/',
+                            'url': STAGING + 'publication/nhs-england-improvement/',
                             'heading': 'Latest publications',
                             'description': 'See our most recent publications and search for documents in our publications library',
                             'content_image': None,
                             'alt_text': ''
                         },
                         {
-                            'url': 'https://staging.nhsei.rkh.co.uk/news/nhs-england-improvement/',
+                            'url': STAGING + 'news/nhs-england-improvement/',
                             'heading': 'News',
                             'description': 'Our headline announcements',
                             'content_image': None,
                             'alt_text': ''
                         },
                         {
-                            'url': 'https://staging.nhsei.rkh.co.uk/gp/',
+                            'url': STAGING + 'gp/',
                             'heading': 'General Practice',
                             'description': 'Supporting GPs and GP-led services across our local communities ',
                             'content_image': None,
                             'alt_text': ''
                         },
                         {
-                            'url': 'https://staging.nhsei.rkh.co.uk/diabetes/',
+                            'url': STAGING + 'diabetes/',
                             'heading': 'Diabetes',
                             'description': 'Improving outcomes for people with diabetes',
                             'content_image': None,

--- a/importer/management/commands/runimport.py
+++ b/importer/management/commands/runimport.py
@@ -18,32 +18,33 @@ from importer.import_publications import PublicationsImporter
 from importer.import_regions import RegionsImporter
 from importer.import_settings import SettingsImporter
 
+from importer.websites import SCRAPY
 # from nhsei_wagtail.importer.import_tags import TagsImporter
 
 
 def get_api_url(app):
     if app == 'categories':
-        return 'https://nhsei-scrapy.rkh.co.uk/api/categories/'
+        return SCRAPY + 'api/categories/'
     if app == 'publication_types':
-        return 'https://nhsei-scrapy.rkh.co.uk/api/publication_types/'
+        return SCRAPY + 'api/publication_types/'
     if app == 'settings':
-        return 'https://nhsei-scrapy.rkh.co.uk/api/settings/'
+        return SCRAPY + 'api/settings/'
     if app == 'regions':
-        return 'https://nhsei-scrapy.rkh.co.uk/api/regions/'
+        return SCRAPY + 'api/regions/'
     if app == 'tags':
-        return 'https://nhsei-scrapy.rkh.co.uk/api/tags/'
+        return SCRAPY + 'api/tags/'
     if app == 'pages':
-        return 'https://nhsei-scrapy.rkh.co.uk/api/pages/'
+        return SCRAPY + 'api/pages/'
     if app == 'posts':
-        return 'https://nhsei-scrapy.rkh.co.uk/api/posts/'
+        return SCRAPY + 'api/posts/'
     if app == 'publications':
-        return 'https://nhsei-scrapy.rkh.co.uk/api/publications/'
+        return SCRAPY + 'api/publications/'
     if app == 'atlas_case_studies':
-        return 'https://nhsei-scrapy.rkh.co.uk/api/atlas_case_studies/'
+        return SCRAPY + 'api/atlas_case_studies/'
     if app == 'blogs':
-        return 'https://nhsei-scrapy.rkh.co.uk/api/blogs/'
+        return SCRAPY + 'api/blogs/'
     if app == 'media':
-        return 'https://nhsei-scrapy.rkh.co.uk/api/media_files?page=349'
+        return SCRAPY + 'api/media_files?page=349'
 
 
 """

--- a/importer/websites.py
+++ b/importer/websites.py
@@ -1,0 +1,4 @@
+# These replace the rkh website links throughout the Importer
+
+SCRAPY = 'http://localhost:8001/'
+STAGING = 'http://localhost:8000/'


### PR DESCRIPTION
## Changes in this PR

There were hardcoded references to `https://staging.nhsei.rkh.co.uk` and `https://nhsei-scrapy.rkh.co.uk/` in the importer code. These now point to `http://localhost:8000` and `:8001` respectively, and are referred to once in `importer/websites.py`.

These changes are completely untested but the previous setup had no chance of working since the RKH websites have been taken down; 

## Next steps

Continue to attempt to import the data from the live NHS E&I website to Wagtail.
