### PR TITLE
Fix test fixture

### DIFF
--- a/cms/home/tests.py
+++ b/cms/home/tests.py
@@ -81,7 +81,7 @@ class TestHomePage(TestCase):
         promo2_header = promo2.find('h3', 'nhsuk-promo__heading')
         self.assertEqual(promo2_header.string, 'Promo Two Heading')
         promo2_image = promo2.find('img', 'nhsuk-promo__img')
-        self.assertTrue('homepage-hero-image' in promo2_image['src'])
+        self.assertTrue('homepage-hero-image' in promo2_image['src'], f"src was {promo2_image['src']} which doesn't contain homepage-hero-image")
 
     def test_home_page_callout(self):
         response = self.client.get('/')

--- a/script/test
+++ b/script/test
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+#if [ $# -eq 0 ]; then
+#  echo "Linting code..."
+#  script/poetry run black .
+#fi
+
+echo "Running tests..."
+docker-compose run --service-ports --rm web bash -c "cd fixtures && ./copy_media.sh && cd .. && python manage.py test cms"


### PR DESCRIPTION
There is a script `fixtures/copy_media.sh` which copies the hero image
and other media into the correct folder for testing -- run that
as a part of the test suite setup

## Next Steps

There are still a lot of error-noise (but not failed tests) probably caused by Elastic Search not being found; find a way to suppress or resolve these errors.