### PR TITLE
Ignoring some files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,7 @@
 node_modules
 npm-debug.log
+media
+db.sqlite3
+requests_cache.sqlite
+backup_*
+.git

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ requirements.dev.txt
 compiledassets
 .DS_Store
 requests_cache.sqlite
+backup_*


### PR DESCRIPTION
.gitignore: ignore backup_ files which are copies of the downloaded website
.dockerignore: the chief one here is requests_cache which is a gigabyte,
which doesn't need to be a part of the Docker context. Added a few other ones --
hiding .git appears to be good practice, the media, and the backup files.

This doesn't impact when the actual website runs.

<!-- Do you need to update the changelog? -->

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps
