### PR TITLE
Disable line length checks in Codeclimate

### DIFF
--- a/.codeclimate.yaml
+++ b/.codeclimate.yaml
@@ -13,3 +13,10 @@ exclude_patterns:
 - "**/vendor/"
 - "**/*_test.go"
 - "**/*.d.ts"
+
+engines:
+  pep8:
+    enabled: true
+    checks:
+      E501: # Line length checks
+        enabled: false


### PR DESCRIPTION
These are a really noisy check, and Black prevents us from committing anything ridiculously long anyway.