### PR TITLE
Replace deprecated pre-commit task

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         exclude: deployment/
       - id: trailing-whitespace
       - id: check-merge-conflict
-      - id: check-byte-order-marker
+      - id: fix-byte-order-marker
       - id: debug-statements
       - id: check-json
   - repo: https://github.com/psf/black


### PR DESCRIPTION
The old `check-byte-order-marker` task has been replaced with `fix-byte-order-marker`.