### PR TITLE
Fix bug: can't load page to make PublicationTypes

### DIFF
--- a/cms/categories/wagtail_hooks.py
+++ b/cms/categories/wagtail_hooks.py
@@ -90,7 +90,6 @@ class PublicationTypeAdmin(ModelAdmin):
         FieldPanel("slug"),
         FieldPanel("description"),
         FieldPanel("wp_id"),
-        FieldPanel("source"),
     ]
 
     def get_publication_type_usage(self, obj):


### PR DESCRIPTION
The admin panel attempts to use the source field, which no longer exists.
Deleted.
