### PR TITLE
Remove hardcoded password from HTTP basic auth

### DIFF
--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -208,9 +208,7 @@ vars().update(EMAIL_CONFIG)
 if os.environ.get("BASIC_AUTH_PASSWORD", False):
     MIDDLEWARE += ["baipw.middleware.BasicAuthIPWhitelistMiddleware"]
     BASIC_AUTH_LOGIN = "nhsei"
-    BASIC_AUTH_PASSWORD = os.environ.get(
-        "BASIC_AUTH_PASSWORD", "hardcodedpasswordpleasechange"
-    )
+    BASIC_AUTH_PASSWORD = os.environ.get("BASIC_AUTH_PASSWORD")
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
Since setting the password is what enables basic auth, there is no case where we can end up with needing a default (or if we do we should error out).