### PR TITLE
Preserve dates with new function and demo code

### DIFF
--- a/cms/core/tests.py
+++ b/cms/core/tests.py
@@ -1,3 +1,53 @@
 from django.test import TestCase
+from cms.blogs.models import Blog, BlogIndexPage
+from cms.pages.models import Page
+from importer.preserve import preserve
 
-# Create your tests here.
+
+class TestInitialImporterDatePreservation(TestCase):
+    def test_date_preservation(self):
+        blog_index_page = None
+        home_page = Page.objects.filter(title="Home")[0]
+
+        try:
+            blog_index_page = BlogIndexPage.objects.get(title="Blog Items Base")
+        except Page.DoesNotExist:
+            blog_index_page = BlogIndexPage(
+                title="Blog Items Base",
+                body="theres a place here for some text",
+                show_in_menus=True,
+                slug="blog-items-base",
+            )
+            home_page.add_child(instance=blog_index_page)
+            rev = blog_index_page.save_revision()
+            rev.publish()
+        first_published_at = "2111-01-01T01:01:01Z"
+        last_published_at = "2222-02-02T02:02:02Z"
+        latest_revision_created_at = "2333-03-03T03:03:03Z"
+        blog_index_page = BlogIndexPage.objects.get(title="Blog Items Base")
+        obj = Blog(
+            title="Preserve",
+            # excerpt = post.get('excerpt'),
+            # dont preset the slug coming from wordpress some are too long
+            body="Preserve",
+            show_in_menus=True,
+            wp_id="0",
+            author="Author",
+            source="Source",
+            wp_slug="Slug",
+            wp_link="Link",
+        )
+        blog_index_page.add_child(instance=obj)
+        obj.first_published_at = first_published_at
+        obj.last_published_at = last_published_at
+        obj.latest_revision_created_at = latest_revision_created_at
+        preserve(obj)
+        # Check that we can update the object and not mangle the date
+        obj = Blog.objects.get(title="Preserve")
+        obj.body = "Well preserved"
+        preserve(obj)
+        obj2 = Blog.objects.get(title="Preserve")
+        assert obj2.body == "Well preserved"
+        assert obj2.first_published_at.year == 2111
+        assert obj2.last_published_at.year == 2222
+        assert obj2.latest_revision_created_at.year == 2333

--- a/importer/import_atlas_case_studies.py
+++ b/importer/import_atlas_case_studies.py
@@ -16,6 +16,7 @@ from cms.categories.models import (
 from wagtail.core.models import Page
 
 from .importer_cls import Importer
+from .preserve import preserve
 import logging
 
 logger = logging.getLogger("importer")
@@ -70,9 +71,6 @@ class AtlasCaseStudiesImporter(Importer):
 
         for atlas_case_study in atlas_case_studies:
 
-            first_published_at = atlas_case_study.get("date")
-            last_published_at = atlas_case_study.get("modified")
-            latest_revision_created_at = atlas_case_study.get("modified")
             page_title = atlas_case_study.get("title")
             if not page_title:
                 page_title = "page has no title"
@@ -91,14 +89,11 @@ class AtlasCaseStudiesImporter(Importer):
                 wp_link=atlas_case_study.get("wp_link"),
             )
             atlas_case_study_index_page.add_child(instance=obj)
-            rev = obj.save_revision()  # this needs to run here
-            rev.publish()
 
-            obj.first_published_at = first_published_at
-            obj.last_published_at = last_published_at
-            obj.latest_revision_created_at = latest_revision_created_at
-            obj.save()
-            rev.publish()
+            obj.first_published_at = atlas_case_study.get("date")
+            obj.last_published_at = atlas_case_study.get("modified")
+            obj.latest_revision_created_at = atlas_case_study.get("modified")
+            preserve(obj)
             sys.stdout.write(".")
 
             # add the categories as related many to many, found this needs to be after the save above

--- a/importer/import_blogs.py
+++ b/importer/import_blogs.py
@@ -7,6 +7,7 @@ from wagtail.core.models import Page
 from django.core.management import call_command
 
 from .importer_cls import Importer
+from .preserve import preserve
 
 # blogs are not from a subsite so rewrite the source blogs to posts
 # they use the same categories
@@ -44,9 +45,6 @@ class BlogsImporter(Importer):
 
         blogs = self.results  # this is json result set
         for blog in blogs:
-            first_published_at = blog.get("date")
-            last_published_at = blog.get("modified")
-            latest_revision_created_at = blog.get("modified")
 
             obj = Blog(
                 title=blog.get("title"),
@@ -61,14 +59,11 @@ class BlogsImporter(Importer):
                 wp_link=blog.get("link"),
             )
             blog_index_page.add_child(instance=obj)
-            rev = obj.save_revision()  # this needs to run here
 
-            obj.first_published_at = first_published_at
-            obj.last_published_at = last_published_at
-            obj.latest_revision_created_at = latest_revision_created_at
-            # probably not the best way to do this but need to update the dates on the page record.
-            obj.save()
-            rev.publish()
+            obj.first_published_at = blog.get("date")
+            obj.last_published_at = blog.get("modified")
+            obj.latest_revision_created_at = blog.get("modified")
+            preserve(obj)
 
             # Create source category
             source = blog.get("source")

--- a/importer/import_pages.py
+++ b/importer/import_pages.py
@@ -8,7 +8,7 @@ from django.utils.html import strip_tags
 from cms.pages.models import BasePage
 from wagtail.core.models import Page
 from importer.utils import URLParser
-
+from importer.preserve import preserve
 from .importer_cls import Importer
 
 
@@ -29,10 +29,6 @@ class PagesImporter(Importer):
         pages = self.results  # this is json result set
 
         for page in pages:
-
-            first_published_at = page.get("date")
-            last_published_at = page.get("modified")
-            latest_revision_created_at = page.get("modified")
 
             """
             Process: We need to import the pages at the top level under the home page as we don't know the
@@ -86,14 +82,11 @@ class PagesImporter(Importer):
             )
 
             home_page.add_child(instance=obj)
-            rev = obj.save_revision()  # this needs to run here
 
-            obj.first_published_at = first_published_at
-            obj.last_published_at = last_published_at
-            obj.latest_revision_created_at = latest_revision_created_at
-            # probably not the best way to do this but need to update the dates on the page record.
-            obj.save()
-            rev.publish()
+            obj.first_published_at = page.get("date")
+            obj.last_published_at = page.get("modified")
+            obj.latest_revision_created_at = page.get("modified")
+            preserve(obj)
             sys.stdout.write(".")
 
         if self.next:

--- a/importer/import_posts.py
+++ b/importer/import_posts.py
@@ -8,6 +8,7 @@ from cms.pages.models import BasePage
 from cms.posts.models import Post, PostIndexPage
 from wagtail.core.models import Page
 
+from .preserve import preserve
 from .importer_cls import Importer
 
 # so we can match the subsite categories for the post index page
@@ -86,9 +87,6 @@ class PostsImporter(Importer):
                 sys.stdout.write(".")
 
             # lets make the posts for each sub site, we're in a loop for each post here
-            first_published_at = post.get("date")
-            last_published_at = post.get("modified")
-            latest_revision_created_at = post.get("modified")
 
             obj = Post(
                 title=post.get("title"),
@@ -103,14 +101,11 @@ class PostsImporter(Importer):
                 wp_link=post.get("link"),
             )
             sub_site_news_index_page.add_child(instance=obj)
-            rev = obj.save_revision()  # this needs to run here
-            rev.publish()
+            obj.first_published_at = post.get("date")
+            obj.last_published_at = post.get("modified")
+            obj.latest_revision_created_at = post.get("modified")
+            preserve(obj)
 
-            obj.first_published_at = first_published_at
-            obj.last_published_at = last_published_at
-            obj.latest_revision_created_at = latest_revision_created_at
-            obj.save()
-            rev.publish()
             sys.stdout.write(".")
 
             # Create source category

--- a/importer/import_publications.py
+++ b/importer/import_publications.py
@@ -19,6 +19,7 @@ from cms.publications.models import (
 from wagtail.core.models import Page
 
 from .importer_cls import Importer
+from .preserve import preserve
 
 logger = logging.getLogger("importer")
 
@@ -119,9 +120,6 @@ class PublicationsImporter(Importer):
                 sys.stdout.write(".")
 
             # lets make the posts for each sub site, we're in a loop for each post here
-            first_published_at = publication.get("date")
-            last_published_at = publication.get("modified")
-            latest_revision_created_at = publication.get("modified")
 
             page_title = publication.get("title")
             if not page_title:
@@ -144,14 +142,10 @@ class PublicationsImporter(Importer):
                 source=FAKE_SOURCE,
             )
             sub_site_publication_index_page.add_child(instance=obj)
-            rev = obj.save_revision()  # this needs to run here
-            rev.publish()
-
-            obj.first_published_at = first_published_at
-            obj.last_published_at = last_published_at
-            obj.latest_revision_created_at = latest_revision_created_at
-            obj.save()
-            rev.publish()
+            obj.first_published_at = publication.get("date")
+            obj.last_published_at = publication.get("modified")
+            obj.latest_revision_created_at = publication.get("modified")
+            preserve(obj)
             sys.stdout.write(".")
 
             # add the publication types as related many to many, found this needs to be after the save above

--- a/importer/preserve.py
+++ b/importer/preserve.py
@@ -1,0 +1,69 @@
+from cms.blogs.models import Blog, BlogIndexPage
+from cms.pages.models import Page
+from django.core.management.base import BaseCommand
+
+
+def preserve(obj):
+    """Save updates to obj (including first-write) without
+    trashing the publication/revision dates"""
+    fpa = obj.first_published_at
+    lpa = obj.last_published_at
+    lrca = obj.latest_revision_created_at
+    rev = obj.save_revision()
+    rev.publish()
+    obj.first_published_at = fpa
+    obj.last_published_at = lpa
+    obj.latest_revision_created_at = lrca
+    obj.save()
+
+
+class Command(BaseCommand):
+    help = "Creates a sample page"
+
+    def handle(self, *args, **options):
+        try:
+            exblog = Blog.objects.get(title="Preserve")
+        except Page.DoesNotExist:
+            pass
+        else:
+            exblog.delete()
+        blog_index_page = None
+        home_page = Page.objects.filter(title="Home")[0]
+
+        try:
+            blog_index_page = BlogIndexPage.objects.get(title="Blog Items Base")
+        except Page.DoesNotExist:
+            blog_index_page = BlogIndexPage(
+                title="Blog Items Base",
+                body="theres a place here for some text",
+                show_in_menus=True,
+                slug="blog-items-base",
+            )
+            home_page.add_child(instance=blog_index_page)
+            rev = blog_index_page.save_revision()
+            rev.publish()
+        first_published_at = "2111-01-01T01:01:01Z"
+        last_published_at = "2222-02-02T02:02:02Z"
+        latest_revision_created_at = "2333-03-03T03:03:03Z"
+        blog_index_page = BlogIndexPage.objects.get(title="Blog Items Base")
+        obj = Blog(
+            title="Preserve",
+            # excerpt = post.get('excerpt'),
+            # dont preset the slug coming from wordpress some are too long
+            body="Preserve",
+            show_in_menus=True,
+            wp_id="0",
+            author="Author",
+            source="Source",
+            wp_slug="Slug",
+            wp_link="Link",
+        )
+        blog_index_page.add_child(instance=obj)
+        obj.first_published_at = first_published_at
+        obj.last_published_at = last_published_at
+        obj.latest_revision_created_at = latest_revision_created_at
+        preserve(obj)
+        # Check that we can update the object and not mangle the date
+        obj = Blog.objects.get(title="Preserve")
+        obj.body = "Well preserved"
+        preserve(obj)

--- a/importer/preserve.py
+++ b/importer/preserve.py
@@ -1,8 +1,3 @@
-from cms.blogs.models import Blog, BlogIndexPage
-from cms.pages.models import Page
-from django.core.management.base import BaseCommand
-
-
 def preserve(obj):
     """Save updates to obj (including first-write) without
     trashing the publication/revision dates"""
@@ -15,55 +10,3 @@ def preserve(obj):
     obj.last_published_at = lpa
     obj.latest_revision_created_at = lrca
     obj.save()
-
-
-class Command(BaseCommand):
-    help = "Creates a sample page"
-
-    def handle(self, *args, **options):
-        try:
-            exblog = Blog.objects.get(title="Preserve")
-        except Page.DoesNotExist:
-            pass
-        else:
-            exblog.delete()
-        blog_index_page = None
-        home_page = Page.objects.filter(title="Home")[0]
-
-        try:
-            blog_index_page = BlogIndexPage.objects.get(title="Blog Items Base")
-        except Page.DoesNotExist:
-            blog_index_page = BlogIndexPage(
-                title="Blog Items Base",
-                body="theres a place here for some text",
-                show_in_menus=True,
-                slug="blog-items-base",
-            )
-            home_page.add_child(instance=blog_index_page)
-            rev = blog_index_page.save_revision()
-            rev.publish()
-        first_published_at = "2111-01-01T01:01:01Z"
-        last_published_at = "2222-02-02T02:02:02Z"
-        latest_revision_created_at = "2333-03-03T03:03:03Z"
-        blog_index_page = BlogIndexPage.objects.get(title="Blog Items Base")
-        obj = Blog(
-            title="Preserve",
-            # excerpt = post.get('excerpt'),
-            # dont preset the slug coming from wordpress some are too long
-            body="Preserve",
-            show_in_menus=True,
-            wp_id="0",
-            author="Author",
-            source="Source",
-            wp_slug="Slug",
-            wp_link="Link",
-        )
-        blog_index_page.add_child(instance=obj)
-        obj.first_published_at = first_published_at
-        obj.last_published_at = last_published_at
-        obj.latest_revision_created_at = latest_revision_created_at
-        preserve(obj)
-        # Check that we can update the object and not mangle the date
-        obj = Blog.objects.get(title="Preserve")
-        obj.body = "Well preserved"
-        preserve(obj)


### PR DESCRIPTION
We try to preserve the first_published_date, last_published_date and
latest_revision_created_at from scrapy/WP (where they're called "date"
and "modified") but we weren't correctly preserving them. There's now
a new function in importer/preserve called preserve(obj) that takes
an object and saves it without mangling these features. For the first
write you should manually add the scrapy data to the object before
calling preserve(obj).