### PR TITLE
Explicitly pin latest version of Wagtail in pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -642,7 +642,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6,<3.9"
-content-hash = "dcc08f23ffd9c29698b5abd5aea8e2ccbe3c5d9fea9dd1433970faf7f96d9f93"
+content-hash = "3de9bd816ece44b2aeff35a4a2673a4d7912a67ff2400bcb76ad987188ac06e1"
 
 [metadata.files]
 anyascii = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = ">=3.6,<3.9"
 python-dateutil = "^2.8.1"
 lxml = "^4.6.3"
 Django = "^3.1, <3.2"
-wagtail = "^2.13.2"
+wagtail = "^2.14.1"
 # Grey Panel Block and others are due to be deleted -- update wagtail-nhsuk-frontend with caution!
 # 0.7.0 was OK for nhsx but...
 wagtail-nhsuk-frontend = "0.4.4"


### PR DESCRIPTION
This fixes an oversight where we updated Wagtail in the dependency lock file, but didn't explicitly pin a higher version in the version specification.