### PR TITLE
Address errors raised by LGTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ pipenv shell
 Install required libraries, on Ubuntu 20.04 linux we need to add the `pg_config` util:
 
 ```bash
-sudo apt install libpq-dev 
+sudo apt install libpq-dev
 ```
 
 Install the virtual env manager `poetry` from https://python-poetry.org/

--- a/importer/management/commands/parse_stream_fields.py
+++ b/importer/management/commands/parse_stream_fields.py
@@ -372,7 +372,10 @@ class Command(BaseCommand):
             title = "Unknown title"
             logger.warn("Missing title: %s | %s", page, page.id)
 
-        if len(content) > 0 and "default_template_hidden_text_section_title" in content[1]:
+        if (
+            len(content) > 0
+            and "default_template_hidden_text_section_title" in content[1]
+        ):
             expander_list = content[1]  # (a list of expanders)
             expanders = ast.literal_eval(
                 expander_list["default_template_hidden_text_blocks"]

--- a/importer/management/commands/parse_stream_fields.py
+++ b/importer/management/commands/parse_stream_fields.py
@@ -454,7 +454,6 @@ class Command(BaseCommand):
         """
         # rich_text = self.block_builder.extract_links(content)
         self.block_builder.extract_links(content)
-        content = content
         for link in self.block_builder.change_links:
             content = content.replace(str(link[0]), str(link[1]))
         block = {

--- a/importer/management/commands/parse_stream_fields.py
+++ b/importer/management/commands/parse_stream_fields.py
@@ -192,8 +192,8 @@ class Command(BaseCommand):
                             content_fields = self.make_expander_group_block(
                                 page.content_fields, page
                             )
-                            for field in content_fields:
-                                body.append(field)
+                            for content_field in content_fields:
+                                body.append(content_field)
 
                             # body.append(content_blocks)
 


### PR DESCRIPTION
LGTM analysis has highlighted two instances of code which is fundamentally wrong, either lines which are doing nothing or lines which can lead to entirely unexpected behaviour.

This PR addresses both of those errors, so we only have warnings and recommendations remaining.