### PR TITLE
Fixes for page moving and category creation in import process

### DIFF
--- a/importer/types/import_atlas_case_studies.py
+++ b/importer/types/import_atlas_case_studies.py
@@ -42,7 +42,7 @@ class AtlasCaseStudiesImporter(Importer, ABC):
                 show_in_menus=True,
                 slug="atlas-case-study-items-base",
             )
-            self.staging_page.add_child(instance=self.atlas_case_study_index_page)
+            self.home_page.add_child(instance=self.atlas_case_study_index_page)
             revision = self.atlas_case_study_index_page.save_revision()
             revision.publish()
             logger.info("Created Atlas Case Study Items Base")

--- a/importer/types/importer_cls.py
+++ b/importer/types/importer_cls.py
@@ -64,14 +64,15 @@ class Importer:
         """
         self.cache = {}
 
+        self.home_page = Page.objects.get(title="Home")
+
         try:
             self.staging_page = Page.objects.get(title=self.STAGING_PAGE_TITLE)
         except Page.DoesNotExist:
             self.staging_page = BasePage(
                 title=self.STAGING_PAGE_TITLE, wp_id=self.STAGING_PAGE_WP_ID
             )
-            home_page = Page.objects.get(title="Home")
-            home_page.add_child(instance=self.staging_page)
+            self.home_page.add_child(instance=self.staging_page)
             self.staging_page.save()
 
         self.now = time.time()

--- a/importer/utils.py
+++ b/importer/utils.py
@@ -50,7 +50,7 @@ class ImportCategoryMapper:
             )
         else:
 
-            category = Category.objects.create(
+            _, category = Category.objects.get_or_create(
                 name=category_from_definitions["name"], slug=slug
             )
             self.cache[slug] = category


### PR DESCRIPTION
This PR corrects the creation of Atlas base page so that `page_mover` import steps can complete successfully.

This also adds extra robustness to category creation to better handle a race condition where the same category can be tried for creation twice before it has reached the category map cache.