### PR TITLE
Remove duplicate ElasticSearch envars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,3 @@ DATABASE_URL=psql://nhsei:secret@db/nhsei
 ES_JAVA_OPTS=-Xms1g -Xmx1g
 discovery.type=single-node
 xpack.security.enabled=false
-
-# Elasticsearch
-#------------------------------------------------------------------------------
-ES_JAVA_OPTS=-Xms1g -Xmx1g
-discovery.type=single-node
-xpack.security.enabled=false
-


### PR DESCRIPTION
## Changes in this PR

* .env.example includes duplicate environment variables for
  ElasticSearch. This removes them.
