### PR TITLE
Add categories to search results

### DIFF
--- a/cms/templates/partials/nhs_components/search_result.html
+++ b/cms/templates/partials/nhs_components/search_result.html
@@ -23,6 +23,10 @@
 
   </span>
 </div>
+{% if result.specific.categorypage_category_relationship %}
 <div class="tag_right">
-  <a href="">{% get_content_type_tag result %}</a>
+  {% for category in result.specific.categorypage_category_relationship.all %}
+    <a href="{% url 'category-detail' category.category.slug %}">{{ category.category }}</a>
+  {% endfor %}
 </div>
+{% endif %}

--- a/packages/custom-styles/_search-results.scss
+++ b/packages/custom-styles/_search-results.scss
@@ -114,6 +114,9 @@ fieldset.sort_by_nhsuk-fieldset.nhsuk-fieldset {
       bottom: 24px;
     }
     padding-top:20px;
+a {
+  margin-left: 1em;
+}
   }
 }
 


### PR DESCRIPTION
All search results now include categories (where they exist), linking to the category overview page.