### PR TITLE
Make search box empty if no query given, not None

### DIFF
--- a/cms/search/tests.py
+++ b/cms/search/tests.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 from django.test import TestCase
 from wagtail.contrib.search_promotions.models import SearchPromotion
 from wagtail.search.models import Query
+import lxml.html
 
 from cms.pages.models import Page, BasePage
 
@@ -148,3 +149,10 @@ class TestPagination(TestCase):
         response = self.client.get("/search/?page=2&query=e")
         self.assertContains(response, "Previous")
         self.assertContains(response, "Next")
+
+class TestSearchBox(TestCase):
+    def test_no_query(self):
+        # If no query is provided, the search bar is empty (not None)
+        response = self.client.get("/search/")
+        root = lxml.html.fromstring(response.rendered_content)
+        self.assertEqual([''], root.xpath('//input[@id="search"]/@value'))

--- a/cms/search/views.py
+++ b/cms/search/views.py
@@ -25,7 +25,7 @@ def search(request):
     date_to=2020-11-29
     """
 
-    query_string = request.GET.get("query", None)
+    query_string = request.GET.get("query", "")
     search_ordering = request.GET.get("order", "-latest_revision_created_at")
     search_type = request.GET.get("content_type", "")
     date_from = request.GET.get("date_from", "")


### PR DESCRIPTION
## Changes in this PR

The word 'None' no longer appears in the search bar if the user visits `/search/`

## Screenshots of UI changes

### Before
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/85497046/163385548-440e1d08-b1b9-47d0-bda8-fe09e489ef57.png">

### After
The search bar is empty if you visit `/search/`