### PR TITLE
Improvements to menu button behaviour

### DIFF
--- a/cms/browse/views.py
+++ b/cms/browse/views.py
@@ -59,6 +59,7 @@ def browse(request, programme, branch):
         request,
         "browse/browse.html",
         {
+            "menu_button_disable_toggle": True,
             "programme": programme,
             "branch": branch,
             "branch_title": branch_title,

--- a/cms/templates/partials/nhs_components/nhs_header.html
+++ b/cms/templates/partials/nhs_components/nhs_header.html
@@ -23,10 +23,10 @@
 
   <div class="nhsuk-grid-row full-width">
   <div class="nhsuk-header__menu nhsuk-width-container">
-    <div id="toggle-menu" aria-controls="header-navigation"aria-label="Open menu"><span class="burger-menu-text">MENU</span>
-      <button id="toggle-menu" aria-controls="header-navigation" class="burger-button" aria-label="Open menu">
-    </button>
-    </div>
+    <a href="{% url 'browse' %}" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">
+      <span class="burger-menu-text">MENU</span>
+      <button class="burger-button"></button>
+    </a>
   </div>
   </div>
   {% include 'partials/megamenu/megamenu.html' %}

--- a/cms/templates/partials/nhs_components/nhs_header.html
+++ b/cms/templates/partials/nhs_components/nhs_header.html
@@ -23,7 +23,7 @@
 
   <div class="nhsuk-grid-row full-width">
   <div class="nhsuk-header__menu nhsuk-width-container">
-    <a href="{% url 'browse' %}" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">
+    <a href="{% url 'browse' %}" {% if not menu_button_disable_toggle %}id="toggle-menu" {% endif %} aria-controls="header-navigation" aria-label="Open menu">
       <span class="burger-menu-text">Menu</span>
       <button class="burger-button"></button>
     </a>

--- a/cms/templates/partials/nhs_components/nhs_header.html
+++ b/cms/templates/partials/nhs_components/nhs_header.html
@@ -24,7 +24,7 @@
   <div class="nhsuk-grid-row full-width">
   <div class="nhsuk-header__menu nhsuk-width-container">
     <a href="{% url 'browse' %}" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">
-      <span class="burger-menu-text">MENU</span>
+      <span class="burger-menu-text">Menu</span>
       <button class="burger-button"></button>
     </a>
   </div>

--- a/packages/custom-styles/_megamenu.scss
+++ b/packages/custom-styles/_megamenu.scss
@@ -115,13 +115,21 @@ Templates: cms/templates/partials/megamenu
       padding-left: 20px;
   }
 }
+
+#toggle-menu {
+  &:focus {
+    background: none;
+    box-shadow: none;
+  }
+}
+
 .burger-menu-text {
   font-weight: bold;
   top: -13px;
   color: white;
-  position:relative;
-}
-.burger-button,.burger-menu-text {
-  cursor:pointer;
+  position: relative;
 }
 
+.burger-button {
+  cursor: pointer;
+}

--- a/packages/custom-styles/_megamenu.scss
+++ b/packages/custom-styles/_megamenu.scss
@@ -128,6 +128,7 @@ Templates: cms/templates/partials/megamenu
   top: -13px;
   color: white;
   position: relative;
+  text-transform: uppercase;
 }
 
 .burger-button {


### PR DESCRIPTION
## Link works without Javascript

The menu link was previously a styled element relying on Javascript to pop the flyover. This is now a proper native link element taking people to Browse if Javascript is disabled.

## Link doesn't pop the flyover in Browse

If we're in the Browse app already, popping the flyover is counter-intuitive and duplicates page content. Instead, just throw people back to the Browse root.