### PR TITLE
Update the version of black in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: debug-statements
       - id: check-json
   - repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 22.3.0
     hooks:
       - id: black
         exclude: migrations/


### PR DESCRIPTION
This solves an issue where black and click wouldn't play nicely together, leading to failures during pre-commit testing.