### PR TITLE
Swap out search backend in development config

### DIFF
--- a/cms/settings/dev.py
+++ b/cms/settings/dev.py
@@ -20,7 +20,7 @@ DATABASES = {
 
 WAGTAILSEARCH_BACKENDS = {
     "default": {
-        "BACKEND": "wagtail.search.backends.db",
+        "BACKEND": "wagtail.search.backends.database",
     }
 }
 


### PR DESCRIPTION
The old `wagtail.search.backends.db` backend has been deprecated in favour of a new `wagtail.search.backends.database` backend. Using the old backend throws deprecation warnings during development.

This PR swaps to using the new default, removing the warnings.