### PR TITLE
html document template contents and main page copy

### DIFF
--- a/cms/publications/templates/publications/publication.html
+++ b/cms/publications/templates/publications/publication.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
+{% load static wagtailuserbar frontend_tags publications_tags %}
 
 {% block content %}
     <article class="nhsuk-width-container">
@@ -70,8 +71,41 @@
         </div>
         <hr>
         <h1>{{ self.title }}</h1>
-        <div id="content">{{ self.body|richtext }}</div>
         {% if self.publication_publication_type_relationship %}
+        <div class="nhsuk-grid-row">
+            <div class="nhsuk-grid-column-one-third nhsuk-u-margin-top-4 content_nav">
+                <nav>
+                    {% get_toc page %}
+                    <!-- <a href="#related_contents">Related Content</a> -->
+                </nav>
+            </div>
+            <div class="nhsuk-grid-column-two-thirds nhsuk-u-margin-top-4">
+                <div id="content">{{ self.body|richtext }}</div>
+                <hr>
+                <div id="see-all-updates" class="nhsuk-review-date last-publication">
+                    <p class="nhsei-body-s">
+                        <strong>Date published:</strong> {{ self.first_published_at|date:'d M Y' }}<br>
+                        <strong>Date last updated:</strong> {{ self.latest_revision_created_at|date:'d M Y' }}
+                    </p>
+                    <details class="nhsuk-details">
+                        <summary class="nhsuk-details__summary">
+                            <span class="nhsuk-details__summary-text">
+                            Show all updates
+                            </span>
+                        </summary>
+                        <div class="nhsuk-details__text">
+                        <!-- functionality to get this to work hasn't been worked out yet. To be implemented when this work has been done -->
+                        </div>
+                    </details>
+                </div>
+                <hr>
+                <!-- <div class="related-content"> -->
+                    <!-- <a name="related_contents"></a> -->
+                    <!-- <h2>Related content</h2> -->
+                    <!-- The related content feature hasn't be implemented yet - plug this in here once it has been done -->
+                <!-- </div> -->
+                <hr>
+            </div>
             <div class="nhsuk-review-date">
                 <p class="nhsuk-body-s">
                     <a name="see-all-updates"></a>

--- a/cms/publications/templates/publications/toc.html
+++ b/cms/publications/templates/publications/toc.html
@@ -1,5 +1,5 @@
 {% if toc_items %}
-  <div>
+  <div id="publication-toc">
     <h2>Contents</h2>
     <ul>
       {% for item in toc_items %}

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -69,7 +69,6 @@
     {% block breadcrumb %}
         {% breadcrumb %}
     {% endblock %}
-    {% get_toc page %}
 
     {% block main %}
     {% block outer_content %}{% endblock%}

--- a/packages/custom-styles/_base.scss
+++ b/packages/custom-styles/_base.scss
@@ -113,3 +113,9 @@
 a:visited {
   color: #005eb8;
 }
+
+.content_nav {
+  nav a {
+    margin-bottom: 15px;
+  }
+}

--- a/packages/custom-styles/_related-nav.scss
+++ b/packages/custom-styles/_related-nav.scss
@@ -69,3 +69,27 @@ button.nhsuk-button.nhsuk-button--secondary-grey {
     }
   }
 }
+
+//related content
+.related-content {
+  ul{
+     position: relative;
+  }
+  ul li {
+    list-style-type: none!important;
+    padding-left: 10px;
+    &:before {
+      content:"—";
+      position: absolute;
+      left : 0;
+    }
+  }
+}
+.last-publication {
+  .nhsei-body-s {
+    margin-bottom:7px;
+  }
+  details {
+    font-size:16px;
+  }
+}


### PR DESCRIPTION
## Changes in this PR

Created the `Content` column
This is comprised of all the `h2` tag headers from the `body` text.

The `Related content` anchor and placeholder has been set up for when this functionality has been set up. The `Related content` functionality is out of scope for this work.

The `Show all updates` frontend is in place. The backend for this is out of scope for this work.

## Screenshots of UI changes

### Before
<img width="1126" alt="Screenshot 2022-04-27 at 14 52 24" src="https://user-images.githubusercontent.com/59832893/165537489-8b5adc9a-c7ed-46cb-a65b-4eab3825129e.png">

### After
<img width="1126" alt="Screenshot 2022-04-27 at 14 51 47" src="https://user-images.githubusercontent.com/59832893/165537499-56f8730f-f140-4147-bf8e-d0a37d531a81.png">
