### PR TITLE
Improve asset pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,7 @@ dmypy.json
 
 # local
 local.py
-/cms/static
+/cms/static_compiled
 /media
 node_modules
 # Terraform
@@ -149,7 +149,7 @@ requirements.dev.txt
 .vscodecompiledassets
 .vscode
 *.swp
-compiledassets
+static_root
 .DS_Store
 requests_cache.sqlite
 backup_*

--- a/cms/publications/views.py
+++ b/cms/publications/views.py
@@ -10,10 +10,7 @@ class PublicationPdfView(WeasyTemplateView):
     template_name = "publications/publication_pdf.html"
 
     pdf_stylesheets = [
-        settings.BASE_DIR
-        / "cms"
-        / settings.STATIC_URL.replace("/", "")
-        / "css/publication_pdf.css",
+        settings.BASE_DIR / "cms/static_compiled/css/publication_pdf.css",
     ]
 
     def get_context_data(self, **kwargs):

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -185,6 +185,7 @@ STATICFILES_FINDERS = [
 
 STATICFILES_DIRS = [
     PROJECT_DIR / "static",
+    PROJECT_DIR / "static_compiled",
     "node_modules",
 ]
 
@@ -194,7 +195,7 @@ STATICFILES_DIRS = [
 # See https://docs.djangoproject.com/en/3.1/ref/contrib/staticfiles/#manifeststaticfilesstorage
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
-STATIC_ROOT = BASE_DIR / "compiledassets"
+STATIC_ROOT = BASE_DIR / "static_root"
 STATIC_URL = "/static/"
 
 # Wagtail settings

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ const browserSync = require('browser-sync').create();
 /**
  * final place for front end css, js and assets
  */
-const assetsFolder = 'cms/static';
+const assetsFolder = 'cms/static_compiled';
 
 /* Remove all files from /cms/static/ */
 const cleanStatic = () => {


### PR DESCRIPTION
This makes some changes to how the asset pipeline works, namely that the `static` folder is now a place we can put our own static assets, and the output from `npm run build` will end up in `static_compiled`. Running `collectstatic` will then move these to `static_root` for serving or if running with `DEBUG` then they'll be served directly.

The upshot of this is we can include assets without having to mess about changing the asset compilation process itself.