### PR TITLE
Removed import of socket.PACKET_BROADCAST

### DIFF
--- a/cms/search/tests.py
+++ b/cms/search/tests.py
@@ -1,4 +1,3 @@
-from socket import PACKET_BROADCAST
 from bs4 import BeautifulSoup
 from django.test import TestCase
 from wagtail.contrib.search_promotions.models import SearchPromotion


### PR DESCRIPTION
I have *no* idea why that was there.
