### PR TITLE
Add News page template html

### DIFF
--- a/cms/posts/templates/posts/post.html
+++ b/cms/posts/templates/posts/post.html
@@ -4,37 +4,35 @@
 {% block content %}
 
 <article class="nhsuk-width-container">
-
-    <div class="nhsuk-u-reading-width">
-        {% if self.categorypage_category_relationship %}
-
-        <div class="nhsuk-body-s">
-            Categories:
-            {% for category in self.categorypage_category_relationship.all %}
-            <a href="{{ self.get_parent.url }}?category={{ category.category.id }}">{{ category.category }}</a>
-            {% endfor %}
-        </div>
-
-        {% endif %}
-
-        <div class="nhsuk-review-date">
-            <div class="nhsuk-body-s">
-                Published: {{ self.first_published_at|date:'d M Y' }}
-            </div>
-            {% if self.last_published_at != self.first_published_at %}
-            <div>
-                Updated on: {{ self.last_published_at|date:'d M Y' }}
-            </div>
-            {% endif %}
-            {% comment %}
-             | Author: {{ self.author }} <i>we are missing the ability to match ID to
-                a name</i>
-            {% endcomment %}
-        </div>
-
-        <h1>{{ self.title }}</h1>
-        {{ self.body|richtext }}
-
-    </div>
+	<div class="nhsuk-grid-row blog_page">
+		<div class="nhsuk-grid-column-two-thirds">
+			<h1>{{ self.title }}</h1>
+			{{ self.body|richtext }}
+		</div>
+		<div class="nhsuk-u-reading-width">
+			{% if self.categorypage_category_relationship %}
+			<div class="nhsuk-body-s">
+				Categories:
+				{% for category in self.categorypage_category_relationship.all %}
+					<a href="{{ self.get_parent.url }}?category={{ category.category.id }}">{{ category.category }}</a>
+				{% endfor %}
+			</div>
+			{% endif %}
+			<div class="nhsuk-review-date">
+				<div class="nhsuk-body-s">
+					Published: {{ self.first_published_at|date:'d M Y' }}
+				</div>
+				{% if self.last_published_at != self.first_published_at %}
+					<div>
+						Updated on: {{ self.last_published_at|date:'d M Y' }}
+					</div>
+				{% endif %}
+				{% comment %}
+					| Author: {{ self.author }} <i>we are missing the ability to match ID to
+					a name</i>
+				{% endcomment %}
+			</div>
+		</div>
+	</div>
 </article>
 {% endblock content %}

--- a/cms/posts/templates/posts/post.html
+++ b/cms/posts/templates/posts/post.html
@@ -9,28 +9,18 @@
 			<h1>{{ self.title }}</h1>
 			{{ self.body|richtext }}
 		</div>
-		<div class="nhsuk-u-reading-width">
-			{% if self.categorypage_category_relationship %}
-			<div class="nhsuk-body-s">
-				Categories:
-				{% for category in self.categorypage_category_relationship.all %}
-					<a href="{{ self.get_parent.url }}?category={{ category.category.id }}">{{ category.category }}</a>
-				{% endfor %}
-			</div>
-			{% endif %}
+		<div class="nhsuk-grid-column-one-third">
 			<div class="nhsuk-review-date">
 				<div class="nhsuk-body-s">
-					Published: {{ self.first_published_at|date:'d M Y' }}
+					<strong>Published:</strong> {{ self.first_published_at|date:'d M Y' }} <br>
+					{% if self.categorypage_category_relationship %}
+						<strong>Categories: </strong>
+						{% for category in self.categorypage_category_relationship.all %}
+							<a href="{{ self.get_parent.url }}?category={{ category.category.id }}">{{ category.category }}</a>
+						{% endfor %}
+					{% endif %}<br>
+					<strong>Content type: </strong><a href="{{ self.get_parent.url  }}">News</a>
 				</div>
-				{% if self.last_published_at != self.first_published_at %}
-					<div>
-						Updated on: {{ self.last_published_at|date:'d M Y' }}
-					</div>
-				{% endif %}
-				{% comment %}
-					| Author: {{ self.author }} <i>we are missing the ability to match ID to
-					a name</i>
-				{% endcomment %}
 			</div>
 		</div>
 	</div>

--- a/cms/posts/templates/posts/post.html
+++ b/cms/posts/templates/posts/post.html
@@ -23,6 +23,15 @@
 				</div>
 			</div>
 		</div>
+		<div class="content_nav">
+			<h2>Latest news</h2>
+			<!-- The related content feature hasn't be implemented yet - plug this in here once it has been done -->
+			<!-- <nav>
+				<a href="">Preparing for roving and mobile vaccination</a>
+				<a href="">Roving and mobile operating models</a>
+				<a href="">Vaccination of children and young people</a>
+			</nav> -->
+		</div>
 	</div>
 </article>
 {% endblock content %}

--- a/cms/posts/tests.py
+++ b/cms/posts/tests.py
@@ -114,11 +114,8 @@ class TestPost(TestCase):
 
         # review date
         # better to test these actual date objects as unittest I think, one for later
-        published_date_container = soup.select_one("main .nhsuk-review-date div:nth-of-type(1)")
-        self.assertIn(published_date_container.text.strip(), "Published: 04 Feb 2021")
-
-        updated_date_container = soup.select_one("main .nhsuk-review-date div:nth-of-type(2)")
-        self.assertIn(updated_date_container.text.strip(), "Updated on: 25 Aug 2021")
+        published_date_container = soup.select_one("main .nhsuk-body-s")
+        self.assertIn(published_date_container.text.strip()[:22], "Published: 04 Feb 2021")
 
         # taxonomy links
         category_1 = soup.select_one("main a:nth-of-type(1)")


### PR DESCRIPTION
## Changes in this PR

Add Header and Body html for News page template
Add meta content 
Add Latest News related content

The related content feature hasn't been implemented yet. The bare bones
has been added in so this can be plugged in once the implementation
has been done.

