### PR TITLE
Specify location of Scrapy server with an environment variable rather than hard coded.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ POSTGRES_USER=nhsei
 POSTGRES_PASSWORD=secret
 
 DATABASE_URL=psql://nhsei:secret@db/nhsei
+
+SCRAPY_ENDPOINT=http://localhost:8001
+
 # Elasticsearch
 #------------------------------------------------------------------------------
 ES_JAVA_OPTS=-Xms1g -Xmx1g

--- a/importer/websites.py
+++ b/importer/websites.py
@@ -1,4 +1,3 @@
-# These replace the rkh website links throughout the Importer
+import os
 
-SCRAPY = "http://nhs-ei.scrapy:8001/"
-STAGING = "http://localhost:8000/"
+SCRAPY = os.environ.get("SCRAPY_ENDPOINT", "http://nhs-ei.scrapy:8001/")


### PR DESCRIPTION

We keep a default value of the old value to not break people's local devs.
