### PR TITLE
Use Arial not Frutiger W01 whilst site not approaching live

### DIFF
--- a/packages/custom-styles/_base.scss
+++ b/packages/custom-styles/_base.scss
@@ -134,3 +134,7 @@ a:visited {
     }
   }
 }
+
+html, body {
+  font-family:Arial, Sans-serif !important;
+};


### PR DESCRIPTION
There are licensing implications if we use Frutiger W01.

https://trello.com/c/fktDryRW/326-remove-all-references-to-paid-for-fonts

## Screenshots of UI changes

### After
![image](https://user-images.githubusercontent.com/85497046/167458967-949e3a56-fd17-4a21-b5e3-5bd3688ed212.png)

## Next steps
Remember to remove before go-live!