### PR TITLE
Backend ACF blocks

### DIFF
--- a/cms/core/acf_blocks.py
+++ b/cms/core/acf_blocks.py
@@ -1,0 +1,99 @@
+# Blocks designed to mimic the behaviour of existing NHS Advanced Custom Fields
+
+from wagtail.core import blocks
+from wagtail.embeds.blocks import EmbedBlock
+from wagtail.images.blocks import ImageChooserBlock
+
+# ===============================
+# Looking for a RecentPostsBlock?
+# It's in cms.categories.blocks
+#
+# Not added a PromoBlock -- might already be in Base?
+# ===============================
+
+class VisitNhsukInfobarBlock(blocks.StaticBlock):
+  "wp_name: visit_nhsuk_infobar"
+
+  class Meta:
+    icon = 'user'
+    template = "blocks/acf/visit_nhsuk_infobar_block.html"
+    admin_text = "Recommends users find medical advice at nhs.uk"
+
+class TopicBlock(blocks.StructBlock):
+  "wp's 'topic_section_component' is a list of these"
+  title = blocks.CharBlock() # topic_title in wp
+  content = blocks.CharBlock() # topic_content in wp; is <p>text</p> ... might be full HTML?
+  page = blocks.PageChooserBlock() # topic_url in wp
+
+  class Meta:
+    icon = 'user'
+    template = "blocks/acf/topic_block.html"
+    help_text = "A topic."
+
+class TopicSectionBlock(blocks.StructBlock):
+  "wp: 'topic_section_component'"
+  title = blocks.CharBlock()
+  topics = blocks.ListBlock(child_block=TopicBlock)
+
+  class Meta:
+    icon = 'user'
+    template = "blocks/acf/topic_section_block.html"
+    help_text = "Topics."
+
+class PriorityBlock(blocks.StructBlock):
+  "wp's 'priorities_component' is a list of these"
+  highlight = blocks.BooleanBlock(required=False) # nhsuk_highlight in wp
+  title = blocks.CharBlock() # priority_title in wp; contains stray HTML
+  page = blocks.PageChooserBlock() # priority_url in wp
+
+  class Meta:
+    icon = 'user'
+    template = "blocks/acf/priority_block.html"
+    help_text = "A priority."
+
+class PrioritiesBlock(blocks.StructBlock):
+  "wp: 'priorities_component'"
+  title = blocks.CharBlock()
+  priorities = blocks.ListBlock(child_block=PriorityBlock)
+
+  class Meta:
+    icon = 'user'
+    template = "blocks/acf/priorities_block.html"
+    help_text = "Priorities."
+
+class VideoBlock(blocks.StructBlock):
+  "wp: 'video_component'"
+  title = blocks.CharBlock() # wp: video_title
+  # video_size: is_half_width
+  # title_link: "" ???
+  embed = EmbedBlock() # wp: youtube_link
+  content = blocks.RichTextBlock() # wp: content, actual HTML (<a>) seen
+  # video_background: false
+  # video_background_colour: "" ???
+
+  class Meta:
+    icon = 'user'
+    template = 'blocks/acf/video_block.html'
+    help_text = "Video with description"
+
+class ArticleBlock(blocks.StructBlock):
+  "wp: 'article_component'"
+  title = blocks.CharBlock() # wp: article_title
+  image = ImageChooserBlock()# wp: article_image
+  image_alignment = blocks.ChoiceBlock([
+    ['right', 'right'],
+    ['left', 'left'],
+  ], default='right') # wp: article_image_alignment; has-right-aligned-image
+  image_size = blocks.ChoiceBlock([
+     ['half', 'half width'],
+     ['third', 'one third width'],
+     ['quarter', 'one quarter width'],
+  ], default='third')  # wp:article_image_size; has-third-width-image
+  # background # wp:article_background; false
+  # background-colour #wp:article_background_colour: "#e8edee"
+  content = blocks.RichTextBlock() # wp: article_content; full HTML
+  page = blocks.PageChooserBlock(required=False) # wp: article_url, optional
+  class Meta:
+    icon = 'user'
+    template = 'blocks/acf/article_block.html'
+    help_text = "A third-of-a-screen article about a page, either this one or another"

--- a/cms/core/blocks.py
+++ b/cms/core/blocks.py
@@ -23,7 +23,15 @@ from wagtailnhsukfrontend.blocks import (
     SummaryListBlock,
 )
 
+from .acf_blocks import (
+    TopicSectionBlock,
+    VisitNhsukInfobarBlock,
+    PrioritiesBlock,
+    VideoBlock,
+    ArticleBlock,
+)
 import cms.categories.blocks
+from wagtail.core import blocks as core_blocks
 
 RICHTEXT_FEATURES_ALL = [
     "h1",
@@ -67,7 +75,13 @@ class CoreBlocks(StreamBlock):
     promo = CardImageBlock(group="Base")
     promo_group = CardGroupBlock(group="Base")
 
-    recent_posts = cms.categories.blocks.RecentPostsBlock(group="Custom")
+    visit_nhsuk_infobar = VisitNhsukInfobarBlock(group="ACF")
+    topic_section = TopicSectionBlock(group="ACF")
+    priorities = PrioritiesBlock(group="ACF")
+    video = VideoBlock(group="ACF")
+    recent_posts = cms.categories.blocks.RecentPostsBlock(group="ACF")
+    article = ArticleBlock(group="ACF")
+
     text = RichTextBlock(
         group="Custom",
         help_text="""
@@ -78,7 +92,7 @@ class CoreBlocks(StreamBlock):
         features=RICHTEXT_FEATURES_ALL,
     )
     html = RawHTMLBlock(
-        group="custom",
+        group="Custom",
         help_text="""
             Use this block to add raw html
         """,

--- a/cms/core/templates/blocks/acf/article_block.html
+++ b/cms/core/templates/blocks/acf/article_block.html
@@ -1,0 +1,4 @@
+{% load wagtailcore_tags wagtailimages_tags %}
+<div class="{{ classname }}">
+  {{value.title}} {% image value.image max-200x200 %} {{value.image_alignment}} {{value.image_size}} {{value.content}} {% pageurl value.page %} {{value.page}}
+</div>

--- a/cms/core/templates/blocks/acf/priorities_block.html
+++ b/cms/core/templates/blocks/acf/priorities_block.html
@@ -1,0 +1,9 @@
+{% load wagtailcore_tags  %}
+<div class="{{ classname }}">
+  {{value.title}}
+
+  {% for priority in value.priorities %}
+    {# find this in priority_block.html #}
+    {% include_block priority %}
+  {% endfor %}
+</div>

--- a/cms/core/templates/blocks/acf/priority_block.html
+++ b/cms/core/templates/blocks/acf/priority_block.html
@@ -1,0 +1,4 @@
+{% load wagtailcore_tags  %}
+<div class="{{ classname }}">
+  {{value.highlight}} {{value.title}} {% pageurl value.page %} {{value.page}}
+</div>

--- a/cms/core/templates/blocks/acf/topic_block.html
+++ b/cms/core/templates/blocks/acf/topic_block.html
@@ -1,0 +1,4 @@
+{% load wagtailcore_tags  %}
+<div class="{{ classname }}">
+  {{value.title}} {{value.content}} {% pageurl page %} {{page.url}}
+</div>

--- a/cms/core/templates/blocks/acf/topic_section_block.html
+++ b/cms/core/templates/blocks/acf/topic_section_block.html
@@ -1,0 +1,10 @@
+{% load wagtailcore_tags  %}
+
+<div class="{{ classname }}">
+  {{value.title}}
+
+  {% for topic in value.topics %}
+    {# find this in topic_block.html #}
+    {% include_block topic %}
+  {% endfor %}
+</div>

--- a/cms/core/templates/blocks/acf/video_block.html
+++ b/cms/core/templates/blocks/acf/video_block.html
@@ -1,0 +1,7 @@
+{% load wagtailcore_tags wagtailembeds_tags %}
+
+<div class="{{ classname }}">
+  {{value.title}}
+  {{value.content}}
+  {% embed value.embed.url max_width=1024 %}
+</div>

--- a/cms/core/templates/blocks/acf/visit_nhsuk_infobar_block.html
+++ b/cms/core/templates/blocks/acf/visit_nhsuk_infobar_block.html
@@ -1,0 +1,4 @@
+<div class="{{ classname }}">
+  <p></p>Visit nhs.uk
+  Find medical advice at nhs.uk</p>
+</div>


### PR DESCRIPTION
Adds the following blocks to emulate the behaviour of the /cancer page

* Visit NHS UK
* Topics
* Priorities
* Videos (with captions)

And one for the / page:

* Articles

I currently anticipate that Promos will be adequately covered by the
promos in the 'Base' section, and we already have significant work for
Recent Posts, which might need work to also cover Recent Case Studies
(which is a publication type)

There may be additional ACFs we need to consider: in scrapy, the
custom_fields_customfieldlayout table contains a number of other ACFs
and a number of additional ACFs are referenced in the Sprint 1 board
https://miro.com/app/board/uXjVOOD13U4=/
