### PR TITLE
326 remove frutiger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6911,7 +6911,7 @@
     },
     "node_modules/nhsuk-frontend": {
       "version": "6.1.0",
-      "resolved": "git+ssh://git@github.com/dxw/nhsuk-frontend.git#6a0997f758ff4d449f71ecc4ed66cef4287bbe99",
+      "resolved": "git+ssh://git@github.com/dxw/nhsuk-frontend.git#29dac119d184d2421f3761844f5c1de5b2ef3603",
       "license": "MIT"
     },
     "node_modules/node-libs-browser": {
@@ -16647,7 +16647,7 @@
       "dev": true
     },
     "nhsuk-frontend": {
-      "version": "git+ssh://git@github.com/dxw/nhsuk-frontend.git#6a0997f758ff4d449f71ecc4ed66cef4287bbe99",
+      "version": "git+ssh://git@github.com/dxw/nhsuk-frontend.git#29dac119d184d2421f3761844f5c1de5b2ef3603",
       "from": "nhsuk-frontend@github:dxw/nhsuk-frontend"
     },
     "node-libs-browser": {

--- a/packages/nhsuk.scss
+++ b/packages/nhsuk.scss
@@ -1,3 +1,4 @@
+$nhsuk-include-font-face: false;
 @import '../node_modules/nhsuk-frontend/packages/nhsuk';
 
 // custom styles


### PR DESCRIPTION
## Changes in this PR

To meet font licensing requirements, disable the inclusion and use of Frutiger and replace with the default fallback font stack in nhsuk-frontend.

## Screenshots of UI changes

### Before

![localhost_8000_ (1)](https://user-images.githubusercontent.com/619082/167613405-5ecc73b5-a34c-43a5-8421-405e920c1a5b.png)

### After

![localhost_8000_](https://user-images.githubusercontent.com/619082/167613426-cc87c3e3-8cf7-4b45-a527-f5db3d1ebdda.png)

## Next steps

- Before launch, [reinstate Frutiger](https://trello.com/c/mIq0qcj8/349-reinstate-frutiger)