### PR TITLE
Refactor service environment variables

### DIFF
--- a/deployment/helm/nhsei-scrapy/templates/deployment.yaml
+++ b/deployment/helm/nhsei-scrapy/templates/deployment.yaml
@@ -49,24 +49,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-            - name: ALLOWED_HOSTS
-              value: "{{ .Values.environment.allowed_hosts }}"
-            - name: DATABASE_URL
-              value: "{{ .Values.environment.database_url }}"
-          #  - name: AZURE_CONNECTION_STRING
-          #    value: "{{ .Values.environment.azure_connection_string }}"
-          #  - name: AZURE_CONTAINER
-          #    value: "{{ .Values.environment.azure_container }}"
-          #  - name: EMAIL_URL
-          #    value: "{{ .Values.environment.email_url }}"
-          #  - name: DEFAULT_FROM_EMAIL
-          #    value: "{{ .Values.environment.default_from_email }}"
-          #  - name: SERVER_EMAIL
-          #    value: "{{ .Values.environment.server_email }}"
-          #  - name: WAGTAILSEARCH_URLS
-          #    value: "{{ .Values.environment.wagtailsearch_urls }}"
-          #  - name: BASIC_AUTH_PASSWORD
-          #    value: "{{ .Values.environment.basic_auth_password }}"
+            {{- range $envKey, $envValue := .Values.environment }}
+            - name: {{ $envKey }}
+              value: $envValue
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deployment/helm/nhsei-scrapy/values.yaml
+++ b/deployment/helm/nhsei-scrapy/values.yaml
@@ -50,14 +50,7 @@ service:
   port: 8001
 
 environment:
-  allowed_hosts: ""
-#  database_url: ""
-#  azure_connection_string: ""
-#  azure_container: ""
-#  email_url: ""
-#  server_email: ""
-#  default_from_email: ""
-#  wagtailsearch_urls: ""
+  {}
 
 ingress:
   enabled: false

--- a/deployment/helm/nhsei-website/templates/deployment.yaml
+++ b/deployment/helm/nhsei-website/templates/deployment.yaml
@@ -48,26 +48,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-            - name: ALLOWED_HOSTS
-              value: "{{ .Values.environment.allowed_hosts }}"
-            - name: SCRAPY_ENDPOINT
-              value: "{{ .Values.environment.scrapy_endpoint }}"
-            - name: DATABASE_URL
-              value: "{{ .Values.environment.database_url }}"
-            - name: AZURE_CONNECTION_STRING
-              value: "{{ .Values.environment.azure_connection_string }}"
-            - name: AZURE_CONTAINER
-              value: "{{ .Values.environment.azure_container }}"
-            - name: EMAIL_URL
-              value: "{{ .Values.environment.email_url }}"
-            - name: DEFAULT_FROM_EMAIL
-              value: "{{ .Values.environment.default_from_email }}"
-            - name: SERVER_EMAIL
-              value: "{{ .Values.environment.server_email }}"
-            - name: WAGTAILSEARCH_URLS
-              value: "{{ .Values.environment.wagtailsearch_urls }}"
-            - name: BASIC_AUTH_PASSWORD
-              value: "{{ .Values.environment.basic_auth_password }}"
+            {{- range $envKey, $envValue := .Values.environment }}
+            - name: {{ $envKey }}
+              value: $envValue
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deployment/helm/nhsei-website/values.yaml
+++ b/deployment/helm/nhsei-website/values.yaml
@@ -50,15 +50,7 @@ service:
   port: 8000
 
 environment:
-  allowed_hosts: ""
-  scrapy_endpoint: ""
-  database_url: ""
-  azure_connection_string: ""
-  azure_container: ""
-  email_url: ""
-  server_email: ""
-  default_from_email: ""
-  wagtailsearch_urls: ""
+  {}
 
 ingress:
   enabled: true

--- a/deployment/kubernetes-cron-jobs.tf
+++ b/deployment/kubernetes-cron-jobs.tf
@@ -20,6 +20,14 @@ resource "helm_release" "cron_jobs" {
     value = local.default_postgres_scrapy_db_url
   }
 
+  dynamic "set" {
+    for_each = local.scrapy_environment_variables
+    content {
+      name  = "jobs.scrapy-run-all-imports.env.${set.key}"
+      value = set.value
+    }
+  }
+
   set {
     name  = "jobs.scrapy-run-all-imports.schedule"
     value = "0 18 * * *"
@@ -79,5 +87,13 @@ resource "helm_release" "cron_jobs" {
   set {
     name  = "jobs.publish-scheduled-pages.env.WAGTAIL_SEARCH_URLS"
     value = "http://${data.kubernetes_service.elasticsearch.spec.0.cluster_ip}:9200"
+  }
+
+  dynamic "set" {
+    for_each = local.web_environment_variables
+    content {
+      name  = "jobs.publish-scheduled-pages.env.${set.key}"
+      value = set.value
+    }
   }
 }

--- a/deployment/kubernetes-service-scrapy.tf
+++ b/deployment/kubernetes-service-scrapy.tf
@@ -20,8 +20,16 @@ resource "helm_release" "scrapy" {
   }
 
   set {
-    name  = "environment.database_url"
+    name  = "environment.DATABASE_URL"
     value = local.default_postgres_scrapy_db_url
+  }
+
+  dynamic "set" {
+    for_each = local.scrapy_environment_variables
+    content {
+      name  = "environment.${set.key}"
+      value = set.value
+    }
   }
 }
 

--- a/deployment/kubernetes-service-web.tf
+++ b/deployment/kubernetes-service-web.tf
@@ -47,27 +47,27 @@ resource "helm_release" "web" {
   }
 
   set {
-    name  = "environment.database_url"
+    name  = "environment.DATABASE_URL"
     value = local.default_postgres_web_db_url
   }
 
   set {
-    name  = "environment.wagtailsearch_urls"
+    name  = "environment.WAGTAILSEARCH_URLS"
     value = "http://${data.kubernetes_service.elasticsearch.spec.0.cluster_ip}:9200"
   }
 
   set {
-    name  = "environment.scrapy_endpoint"
+    name  = "environment.SCRAPY_ENDPOINT"
     value = "http://${data.kubernetes_service.scrapy.spec.0.cluster_ip}:8001/"
   }
 
   set {
-    name  = "environment.azure_connection_string"
+    name  = "environment.AZURE_CONNECTION_STRING"
     value = "DefaultEndpointsProtocol=https;AccountName=${azurerm_storage_account.default.name};AccountKey=${azurerm_storage_account.default.primary_access_key};EndpointSuffix=core.windows.net"
   }
 
   set {
-    name  = "environment.azure_container"
+    name  = "environment.AZURE_CONTAINER"
     value = azurerm_storage_container.web_media.name
   }
 

--- a/deployment/locals.tf
+++ b/deployment/locals.tf
@@ -11,6 +11,7 @@ locals {
   acr_options                   = var.acr_options
   web_image_tag                 = var.web_image_tag
   web_environment_variables     = var.web_environment_variables
+  scrapy_environment_variables  = var.scrapy_environment_variables
   aks_version                   = var.aks_version
   aks_nodes_address_cidr        = cidrsubnet(local.virtual_network_address_space, 8, 1)
   aks_vm_size                   = var.aks_vm_size

--- a/deployment/terraform.tfvars.example
+++ b/deployment/terraform.tfvars.example
@@ -11,11 +11,13 @@ acr_options = {
 }
 web_image_tag = "sha-123"
 web_environment_variables = {
-  email_url = "smtp://user@:password@localhost:25"
-  default_from_email = "web@example.com"
-  server_email = "web-server@example.com"
-  allowed_hosts = "example.com,example-2.com"
-  basic_auth_password = "secret"
+  EMAIL_URL = "smtp://user@:password@localhost:25"
+  DEFAULT_FROM_EMAIL = "web@example.com"
+  SERVER_EMAIL = "web-server@example.com"
+  ALLOWED_HOSTS = "example.com,example-2.com"
+  BASIC_AUTH_PASSWORD = "secret"
+}
+scrapy_environment_variables = {
 }
 aks_version = "1.21.9"
 aks_vm_size = "Standard_DS2_v2"

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -60,6 +60,12 @@ variable "web_environment_variables" {
   default     = {}
 }
 
+variable "scrapy_environment_variables" {
+  description = "Web environment variables"
+  type        = map(string)
+  default     = {}
+}
+
 variable "aks_version" {
   description = "Azure Kubenetes Service version"
   type        = string


### PR DESCRIPTION
* Service environment variables can now just be added to the maps in
  tfvars, eg. `web_environment_variables` or `scrapy_environment_variables`
* These will be passed through to both the service and cron job
* There is now no requirement to modify the helm charts to add
  environment variables in the future