### PR TITLE
Implement landing page blocks

### DIFF
--- a/cms/core/blocks.py
+++ b/cms/core/blocks.py
@@ -1,9 +1,15 @@
 from wagtail.core.blocks import (
     RawHTMLBlock,
     StreamBlock,
+    StructBlock,
+    CharBlock,
 )
 from wagtail.core.blocks.field_block import (
     RichTextBlock,
+)
+
+from wagtail.images.blocks import (
+    ImageChooserBlock,
 )
 
 from wagtailnhsukfrontend.blocks import (
@@ -49,6 +55,14 @@ RICHTEXT_FEATURES_ALL = [
 ]
 
 
+class PageHeadingBlock(StructBlock):
+    text = RichTextBlock()
+    image = ImageChooserBlock(required=False)
+
+    class Meta:
+        template = "blocks/page_heading_block.html"
+
+
 class CoreBlocks(StreamBlock):
     action_link = ActionLinkBlock(group="Base")
     care_card = CareCardBlock(group="Base")
@@ -66,6 +80,7 @@ class CoreBlocks(StreamBlock):
     summary_list = SummaryListBlock(group="Base")
     promo = CardImageBlock(group="Base")
     promo_group = CardGroupBlock(group="Base")
+    page_heading = PageHeadingBlock(group="Custom")
 
     recent_posts = cms.categories.blocks.RecentPostsBlock(group="Custom")
     text = RichTextBlock(

--- a/cms/core/blocks.py
+++ b/cms/core/blocks.py
@@ -3,9 +3,11 @@ from wagtail.core.blocks import (
     StreamBlock,
     StructBlock,
     CharBlock,
+    ListBlock,
 )
 from wagtail.core.blocks.field_block import (
     RichTextBlock,
+    PageChooserBlock,
 )
 
 from wagtail.images.blocks import (
@@ -63,6 +65,19 @@ class PageHeadingBlock(StructBlock):
         template = "blocks/page_heading_block.html"
 
 
+class PromotedLinkBlock(StructBlock):
+    title = CharBlock()
+    image = ImageChooserBlock()
+    link = PageChooserBlock()
+
+
+class PromotedLinksBlock(StructBlock):
+    links = ListBlock(PromotedLinkBlock())
+
+    class Meta:
+        template = "blocks/promo_links_block.html"
+
+
 class CoreBlocks(StreamBlock):
     action_link = ActionLinkBlock(group="Base")
     care_card = CareCardBlock(group="Base")
@@ -81,6 +96,7 @@ class CoreBlocks(StreamBlock):
     promo = CardImageBlock(group="Base")
     promo_group = CardGroupBlock(group="Base")
     page_heading = PageHeadingBlock(group="Custom")
+    promoted_links = PromotedLinksBlock(group="Custom")
 
     recent_posts = cms.categories.blocks.RecentPostsBlock(group="Custom")
     text = RichTextBlock(

--- a/cms/core/templates/blocks/page_heading_block.html
+++ b/cms/core/templates/blocks/page_heading_block.html
@@ -1,0 +1,18 @@
+{% load wagtailimages_tags %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+    {% if self.text %}
+      <div>
+        <p class="nhsuk-body-s">{{ self.text }}</p>
+      </div>
+    {% endif %}
+  </div>
+  {% if self.image %}
+    <div class="nhsuk-grid-column-one-third">
+      <figure class="nhsuk-image">
+        {% image self.image width-600 class="nhsuk-image__img" %}
+      </figure>
+    </div>
+  {% endif %}
+</div>

--- a/cms/core/templates/blocks/promo_links_block.html
+++ b/cms/core/templates/blocks/promo_links_block.html
@@ -1,0 +1,16 @@
+{% load wagtailimages_tags %}
+
+<div class="nhsuk-grid-row component-promos has-three-items">
+  {% for link in value.links %}
+    <div class="nhsuk-grid-column-one-third">
+      <figure class="nhsuk-image">
+        {% image link.image fill-400x150 class="nhsuk-image__img" %}
+      </figure>
+      <h3><a href="{{ link.link.url }}" class="nhsuk-body-m">{{ link.title }}</a><h3>
+    </div>
+    {% if forloop.counter|divisibleby:3 and not forloop.last %}
+      </div>
+      <div class="nhsuk-grid-row component-promos has-three-items">
+    {% endif %}
+  {% endfor %}
+</div>

--- a/cms/core/templates/blocks/recent_posts_block.html
+++ b/cms/core/templates/blocks/recent_posts_block.html
@@ -1,29 +1,43 @@
+{% load static wagtailcore_tags frontend_tags %}
 
-<div class="nhsuk-panel-with-label">
-  <h3 class="nhsuk-panel-with-label__label">{{ value.title }}</h3>
-  <div class="nhsuk-grid-row">
+<div class="nhsuk-u-margin-top-6 post-component category-latest" >
+  <div class="nhsuk-grid-row" >
     <div class="nhsuk-grid-column-full">
-      <div class="nhsuk-grid-row">
-        <ol class="nhsuk-list">
-          {% for item in queryset.posts %}
-          <li>
-            <article class="nhsuk-u-margin-bottom-4">
-              <h2 class="nhsuk-heading-xs nhsei-list-title nhsuk-u-margin-bottom-1">
-                <a href="{{item.record.url}}">
-                {{item.record.title}}</a>
-              </h2>
-              <span class="nhsuk-body-s">
-                <div style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">{{item.record.blurb}}</div>
-              <span class="nhsuk-tag nhsuk-tag--white">{{ item.tag }}</span>
-              <span class="nhsei-list-meta">Last updated
-              <time class="date" datetime="">{{ item.record.last_published_at|date:'d M Y' }}</time></span>
-              </span>
-            </article>
-          </li>
-          {% endfor %}
-        </ol>
-        <a href="/news/nhs-england-improvement/">View all -- TODO set categories???</a>
-      </div>
+      <h2>{{ value.title }}</h2>
     </div>
   </div>
+  <div class="nhsuk-grid-row">
+    {% for item in queryset.posts %}
+    {% if forloop.first %}
+      <div class="nhsuk-grid-column-two-thirds item-card">
+    {% else %}
+      <div class="nhsuk-grid-column-one-third item-card">
+    {% endif %}
+        <h3><a href="{{item.record.url}}">{{item.record.title}}</a></h3>
+        <div class="rich-text content">
+          <p>{{item.record.blurb}}</p>
+        </div>
+        <div class="entry-meta group">
+          <strong>Published: </strong><time class="post-meta" datetime="{{ item.record.last_published_at|date:'Y-m-d' }}">
+            {{ item.record.last_published_at|date:'d M Y' }}</time>
+          <br>
+          <strong>Content type:</strong> {% get_content_type_tag item.record %}
+          {% comment %}
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path class="icon" d="M3.74 11.2A24.31 24.31 0 0 1 .39 11a.43.43 0 0 1-.3-.2.38.38 0 0 1-.09-.34c.22-.95.17-1.27 1.07-1.9s1.8-1 2.12-1.37A.78.78 0 0 0 3.27 6a3.17 3.17 0 0 1-.78-3.58A2.48 2.48 0 0 1 4.8 1.07a2.48 2.48 0 0 1 2.32 1.36 3 3 0 0 1 .27 1.2 3.56 3.56 0 0 0-2.82 2 4.32 4.32 0 0 0 .72 4.6c-.15.1-.33.2-.5.3-.34.22-.7.42-1.05.67zm-.15 3.55a.43.43 0 0 1-.3-.2.38.38 0 0 1-.07-.35c.22-.95.17-1.27 1.07-1.9s1.8-1 2.12-1.37a.78.78 0 0 0 .07-1.18 3.17 3.17 0 0 1-.78-3.58A2.48 2.48 0 0 1 8 4.8a2.48 2.48 0 0 1 2.32 1.37 3.17 3.17 0 0 1-.78 3.58.78.78 0 0 0 .07 1.18c.32.35 1.32.8 2.12 1.37s.85.95 1.07 1.9a.44.44 0 0 1-.07.35.43.43 0 0 1-.3.2 31.21 31.21 0 0 1-4.43.18 30.9 30.9 0 0 1-4.41-.18zm12.33-3.93a.43.43 0 0 1-.3.2 24.67 24.67 0 0 1-3.35.18c-.35-.25-.72-.45-1-.65a5.21 5.21 0 0 1-.52-.3 4.27 4.27 0 0 0 .7-4.6 3.52 3.52 0 0 0-2.8-2 3 3 0 0 1 .27-1.2 2.48 2.48 0 0 1 2.28-1.38 2.48 2.48 0 0 1 2.32 1.37A3.17 3.17 0 0 1 12.74 6a.78.78 0 0 0 .06 1.2c.32.35 1.32.8 2.12 1.37s.85.95 1.07 1.9a.44.44 0 0 1-.07.34z"></path></svg>
+          <a href="https://www.england.nhs.uk/author/dr-prathiba-chitsabesan/" title="Posts by Professor Prathiba Chitsabesan" class="author url fn" rel="author">Professor Prathiba Chitsabesan</a>
+          {% endcomment %}
+        </div>
+      </div>
+      {% if forloop.counter|add:1|divisibleby:3 and not forloop.last %}
+        </div>
+        <hr>
+        <div class="nhsuk-grid-row">
+    {% endif %}
+    {% endfor %}
+  </div>
+  {% if category and see_all_link %}
+    <div class="nhsuk-grid-column-full nhsuk-u-margin-top-4">
+      <h4><a href="{% url 'category-detail' value.category.slug %}" class="float-right nhsuk-body-m">View all the latest</a><h4>
+    </div>
+  {% endif %}
 </div>

--- a/cms/pages/tests.py
+++ b/cms/pages/tests.py
@@ -19,42 +19,24 @@ class TestComponentsPage(TestCase):
         response = self.client.get("/component-page/")
         soup = BeautifulSoup(response.content, "html.parser")
 
-        panel = soup.select_one("main .nhsuk-panel-with-label")
+        panel = soup.select_one("main .category-latest")
 
-        heading = panel.select_one("h3")
+        heading = panel.select_one("h2")
         self.assertEqual(heading.text, "Recent Posts")
 
-        # first list is the left side on desktop
-        first_list = panel.find_all("ol")[0]
-        first_list_item_1_link = first_list.select_one("li:nth-child(1) article h2 a")
+        items = panel.find_all("div", class_="item-card")
 
-        self.assertEqual(first_list_item_1_link["href"], "/post-index-page/post-two/")
-        self.assertEqual(first_list_item_1_link.text.strip(), "Post Two")
+        first_item = items[0]
+        first_item_link = first_item.select_one("a")
 
-        first_list_item_1_label = first_list.select_one(
-            "li:nth-child(1) article span span:nth-of-type(1)"
-        )
-        self.assertEqual(first_list_item_1_label.text.strip(), "News")
+        self.assertEqual(first_item_link["href"], "/post-index-page/post-two/")
+        self.assertEqual(first_item_link.text.strip(), "Post Two")
 
-        first_list_item_1_date = first_list.select_one(
-            "li:nth-child(1) article span span:nth-of-type(2) time"
-        )
-        self.assertGreater(len(first_list_item_1_date.text.split()), 0)
+        second_item = items[1]
+        second_item_link = second_item.select_one("a")
 
-        first_list_item_2_link = first_list.select_one("li:nth-child(2) article h2 a")
-
-        self.assertEqual(first_list_item_2_link["href"], "/post-index-page/post-one/")
-        self.assertEqual(first_list_item_2_link.text.strip(), "Post One")
-
-        first_list_item_2_label = first_list.select_one(
-            "li:nth-child(2) article span span:nth-of-type(1)"
-        )
-        self.assertEqual(first_list_item_2_label.text.strip(), "News")
-
-        first_list_item_2_date = first_list.select_one(
-            "li:nth-child(2) article span span:nth-of-type(2) time"
-        )
-        self.assertGreater(len(first_list_item_2_date.text.split()), 0)
+        self.assertEqual(second_item_link["href"], "/post-index-page/post-one/")
+        self.assertEqual(second_item_link.text.strip(), "Post One")
 
     def test_all_common_blocks(self):
         response = self.client.get("/base-page/")

--- a/packages/custom-styles/_base.scss
+++ b/packages/custom-styles/_base.scss
@@ -163,3 +163,51 @@ a:visited {
     }
   }
 }
+
+.category-latest {
+
+  svg {
+    width: 16px;
+    height: 16px;
+    top: 2px;
+    position: relative;
+    margin: 0 5px 0 0;
+  }
+
+  span.post-author {
+      padding-left: 20px;
+  }
+  a.nhsuk-body-m {
+    color: $nhsuk-link-color;
+    @media (max-width:740px) {
+      font-size:19px;
+    }
+  }
+
+  .float-right {
+    float:right;
+  }
+
+  .item-card {
+    @media (min-width:740px) {
+      border-right: 1px solid $nhsuk-border-color;
+    }
+    @media (max-width:740px) {
+      border-bottom: 1px solid $nhsuk-border-color;
+      display: block;
+    }
+    &:last-child {
+      border: none;
+    }
+    h3 {
+      @media (max-width:740px) {
+        margin-top: 32px;
+      }
+    }
+  }
+
+  .nhsuk-grid-row{
+    display: flex;
+    flex-wrap: wrap;
+  }
+}

--- a/packages/custom-styles/_base.scss
+++ b/packages/custom-styles/_base.scss
@@ -155,3 +155,11 @@ a:visited {
     top:4px;
   }
 }
+
+.component-promos.has-three-items {
+  .nhsuk-image__img {
+     @media (min-width:740px) {
+      max-height:136px;
+    }
+  }
+}


### PR DESCRIPTION
## Changes in this PR

- Add new layout block for page headings
  This is a heading text and optional image designed for landing pages It is different from a text block with right-floating image since it uses the page layout grid.

- Add promoted links blocks
  This takes an arbitrary number of links to promote and splits them into rows of no more than 3.

- Add block for recent content
  Updates the formatting for the recent posts block so it can be used in landing pages. This content dynamically updates.

## Screenshot
![localhost_8000_cancer_](https://user-images.githubusercontent.com/619082/167871920-82409c3b-443d-4126-8d3d-eb70db0571a5.png)

