### PR TITLE
Fix helm chart environment variable values

### DIFF
--- a/deployment/helm/nhsei-scrapy/templates/deployment.yaml
+++ b/deployment/helm/nhsei-scrapy/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           env:
             {{- range $envKey, $envValue := .Values.environment }}
             - name: {{ $envKey }}
-              value: $envValue
+              value: {{ $envValue }}
             {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deployment/helm/nhsei-website/templates/deployment.yaml
+++ b/deployment/helm/nhsei-website/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           env:
             {{- range $envKey, $envValue := .Values.environment }}
             - name: {{ $envKey }}
-              value: $envValue
+              value: {{ $envValue }}
             {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
* Ensures the actual environment variable value is used, rather than `$envValue`