### PR TITLE
Disable web autoscaling

### DIFF
--- a/deployment/helm/nhsei-website/values.yaml
+++ b/deployment/helm/nhsei-website/values.yaml
@@ -83,7 +83,7 @@ resources:
   #   memory: 128Mi
 
 autoscaling:
-  enabled: true
+  enabled: false
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
* Use the set amount of replicas until we can determine which metrics to
  scale on