### PR TITLE
286-amend

### DIFF
--- a/cms/browse/templates/browse/browse.html
+++ b/cms/browse/templates/browse/browse.html
@@ -14,7 +14,7 @@
     <div class="browse {% if leaf_items|length > 0 %} mobile_menu {% else %}browse--two-columns{% endif %}">
     {# programmes start #}
       <div id="root" class="browse__root-pane">
-        <h2>Programmes</h2>
+        <h2 class="nhsuk-visually-hidden">Programmes</h2>
         {% for item in programmes %}
           <ul class="browse__list">
             <li>
@@ -24,7 +24,7 @@
             </li>
           </ul>
         {% endfor %}
-        <h2>Corporate</h2>
+        <h2 class="nhsuk-visually-hidden">Corporate</h2>
         {% flat_menu handle="corporate" template="partials/corporate_links.html" %}
       </div>
     {# programmes end #}

--- a/packages/custom-styles/_browse.scss
+++ b/packages/custom-styles/_browse.scss
@@ -16,7 +16,7 @@
     display: block;
     width: 25%;
     margin-right: 0;
-
+    border-right: 1px solid $nhsuk-link-active-color;
   }
   @media (max-width:641px){
     display:none;
@@ -90,7 +90,6 @@
   .hub {
     background-color:#E8EDEE;
     color:black;
-    border:1px solid $color_nhsuk-blue;
     &:after {
       display:none;
     }
@@ -122,7 +121,6 @@
   background: #fff;
   @media (min-width:641px){
     border-right: 1px solid $nhsuk-link-active-color;
-    border-left: 1px solid $nhsuk-link-active-color;
     width: 35%;
     .browse__section-pane .browse__heading {
       padding-left: 15px;
@@ -144,7 +142,7 @@
 .browse--two-columns {
 .browse__section-pane {
   .browse__link {
-    padding-left:10px;
+    padding-left:20px;
       h3 {
         color:$nhsuk-link-color;
       }
@@ -186,15 +184,6 @@
 
 .browse__inner {
     padding-bottom: 30px;
-    @media (min-width:641px){
-      padding-left: 5px;
-      padding-right: 5px;
-      .browse__link--active {
-        margin-left:-5px;
-        padding-left:25px;
-        margin-right:-5px
-      }
-    }
   .browse__heading {
     @media (min-width:641px){
       padding-left: 20px;

--- a/packages/custom-styles/_megamenu.scss
+++ b/packages/custom-styles/_megamenu.scss
@@ -82,7 +82,7 @@ Templates: cms/templates/partials/megamenu
       }
       li {
         @media (min-width:980px){
-          min-height: 120px;
+          min-height: 100px;
         }
         margin-bottom: 15px;
         display: block;
@@ -99,6 +99,9 @@ Templates: cms/templates/partials/megamenu
     }
     a {
       font-weight:bold;
+      font-size:18px;
+      margin-bottom: 5px;
+      display: block;
     }
     span {
       font-size: 16px;


### PR DESCRIPTION
## Changes in this PR
- Reduce the padding between all of the Programmes horizontally.
- Add a little more padding between the Programme title and its description (just a few pixels)
- Change styling of 'Hubs' to have the highlight a shade of blue with no border and be the same width as the menu.
- Visual hide titles programme and corporate

## Screenshots of UI changes
<img width="788" alt="Screenshot 2022-05-12 at 14 03 45" src="https://user-images.githubusercontent.com/10596845/168081057-1393475a-570f-457b-8e95-37443b5737ed.png">
<img width="1328" alt="Screenshot 2022-05-12 at 14 05 28" src="https://user-images.githubusercontent.com/10596845/168081366-40333bfa-b721-469e-8c12-1b520162e938.png">

