### PR TITLE
Add categories and sources for Greener NHS and regional sites

### DIFF
--- a/importer/category_map.py
+++ b/importer/category_map.py
@@ -376,8 +376,8 @@ CATEGORY_MAP = {
         "1452": "severe-weather-advice",  # winter-news-and-advice
         "2876": "nhs-workforce",  # workforce
         "3771": "carers",  # young-carers
-        "3775": "innovation", # nhs-accelerated-access-collaborative
-        "3776": "statistics", # survey
+        "3775": "innovation",  # nhs-accelerated-access-collaborative
+        "3776": "statistics",  # survey
     },
     "categories-aac": {
         "10": "innovation",  # artificial-intelligence
@@ -398,6 +398,8 @@ CATEGORY_MAP = {
         "1": [],  # uncategorized
     },
     "categories-greenernhs": {
+        "13": ["greener-nhs", "sustainability"],  # greener-nhs
+        "12": ["greener-nhs", "sustainability"],  # greener-nhs, nested
         "9": "sustainability",  # net-zero
         "5": [],  # news-and-blogs
         "1": [],  # uncategorized
@@ -414,5 +416,36 @@ CATEGORY_MAP = {
         "3371": "london",
         "3372": "south-east",
         "3373": "south-west",
+    },
+    "categories-south": {
+        "191": "blogs",
+        "3": "news",
+    },
+    "categories-london": {
+        "11": "carers",  # care forum
+        "3": "news",
+    },
+    "categories-east-of-england": {
+        "13": [
+            "nursing",
+            "maternity-midwifery-and-neonatal",
+        ],  # nursing and midwifery
+        "3": "news",
+        "1": [],  # uncat
+    },
+    "categories-midlands": {
+        "3": "news",
+        "1": [],  # uncat
+    },
+    "categories-north-east-yorkshire": {
+        "3": "news",
+        "1": [],  # uncat
+    },
+    "categories-north-west": {
+        "2": "news",
+        "1": [],  # uncat
+    },
+    "categories-south-east": {
+        "1": "news",
     },
 }

--- a/importer/management/commands/delete_media_files.py
+++ b/importer/management/commands/delete_media_files.py
@@ -15,6 +15,13 @@ SOURCES = {
     "media-improvement-hub": "Improvement Hub",
     "media-non-executive-opportunities": "Non-executive opportunities",
     "media-rightcare": "Right Care",
+    "media-north-east-yorkshire": "North East and Yorkshire",
+    "media-south": "South West",
+    "media-london": "London",
+    "media-east-of-england": "East of England",
+    "media-midlands": "Midlands",
+    "media-north-west": "North West",
+    "media-south-east": "South East",
 }
 
 

--- a/importer/types/import_media_files.py
+++ b/importer/types/import_media_files.py
@@ -29,6 +29,13 @@ SOURCES = {
     "media-improvement-hub": "Improvement Hub",
     "media-non-executive-opportunities": "Non-executive opportunities",
     "media-rightcare": "Right Care",
+    "media-north-east-yorkshire": "North East and Yorkshire",
+    "media-south": "South West",
+    "media-london": "London",
+    "media-east-of-england": "East of England",
+    "media-midlands": "Midlands",
+    "media-north-west": "North West",
+    "media-south-east": "South East",
 }
 
 

--- a/importer/types/import_posts.py
+++ b/importer/types/import_posts.py
@@ -23,6 +23,13 @@ POST_SOURCES_TO_CATEGORY_SOURCES = {
     "posts-improvement-hub": "categories-improvement-hub",
     "posts-non-executive-opportunities": "categories-non-executive" "-opportunities",
     "posts-rightcare": "categories-rightcare",
+    "posts-north-east-yorkshire": "North East and Yorkshire",
+    "posts-south": "South West",
+    "posts-london": "London",
+    "posts-east-of-england": "East of England",
+    "posts-midlands": "Midlands",
+    "posts-north-west": "North West",
+    "posts-south-east": "South East",
 }
 
 # so we can a post to a sub site and build out sub site post index pages

--- a/importer/types/import_publication_types.py
+++ b/importer/types/import_publication_types.py
@@ -17,6 +17,13 @@ SOURCES = {
     "publication_types-improvement-hub": "Improvement Hub",
     "publication_types-non-executive-opportunities": "Non-executive " "opportunities",
     "publication_types-rightcare": "Right Care",
+    "publication_types-north-east-yorkshire": "North East and Yorkshire",
+    "publication_types-south": "South West",
+    "publication_types-london": "London",
+    "publication_types-east-of-england": "East of England",
+    "publication_types-midlands": "Midlands",
+    "publication_types-north-west": "North West",
+    "publication_types-south-east": "South East",
 }
 
 

--- a/importer/types/import_publications.py
+++ b/importer/types/import_publications.py
@@ -33,6 +33,13 @@ PUBLICATION_SOURCES = {
     "publications-improvement-hub": "Improvement Hub",
     "publications-non-executive-opportunities": "Non-executive opportunities",
     "publications-rightcare": "Right Care",
+    "publications-north-east-yorkshire": "North East and Yorkshire",
+    "publications-south": "South West",
+    "publications-london": "London",
+    "publications-east-of-england": "East of England",
+    "publications-midlands": "Midlands",
+    "publications-north-west": "North West",
+    "publications-south-east": "South East",
 }
 
 # so we can match the subsite categories for the publications pages

--- a/importer/types/importer_cls.py
+++ b/importer/types/importer_cls.py
@@ -606,6 +606,13 @@ class DocumentsBuilder:
             "publications-improvement-hub": "Improvement Hub",
             "publications-non-executive-opportunities": "Non-executive opportunities",
             "publications-rightcare": "Right Care",
+            "publications-north-east-yorkshire": "North East and Yorkshire",
+            "publications-south": "South West",
+            "publications-london": "London",
+            "publications-east-of-england": "East of England",
+            "publications-midlands": "Midlands",
+            "publications-north-west": "North West",
+            "publications-south-east": "South East",
         }
 
         # print(self.document)


### PR DESCRIPTION
The website importer will fail if the regional sites aren't listed in various SOURCES lists or if they have categories that aren't mapped from WordPress to Wagtail. So we add them.

The regional sites haven't been imported before, so they need new
mappings, and there are additional Greener NHS categories. An attempt
has been made at getting plausible mappings.

News and Blogs have been mapped to the correct sections, and "uncategorised" removed.

The less obvious mappings that have been made are:
```
     "categories-greenernhs": {
+        "13": ["greener-nhs", "sustainability"], # greener-nhs
```
https://www.england.nhs.uk/greenernhs/category/a-greener-nhs/


```
+        "12": ["greener-nhs", "sustainability"], # greener-nhs, nested
```
(Doesn't actually contain any documents, so irrelevant)
https://www.england.nhs.uk/greenernhs/category/a-greener-nhs/a-greener-nhs-a-greener-nhs/

```
+    "categories-london": {
+        "11": "carers", # care forum
```
https://www.england.nhs.uk/london/category/care-forum/

```
+    "categories-east-of-england": {
+        "13": ["nursing",
+               "maternity-midwifery-and-neonatal",], # nursing and midwifery
```
https://www.england.nhs.uk/east-of-england/category/nursing-and-midwifery/
