### PR TITLE
Keep example up to date with reality

### DIFF
--- a/deployment/terraform.tfvars.example
+++ b/deployment/terraform.tfvars.example
@@ -10,7 +10,7 @@ acr_options = {
   resource_group = "nhsei-website-container"
 }
 web_image_tag = "sha-123"
-web_replica_count = 3
+web_replica_count = 1
 web_environment_variables = {
   EMAIL_URL = "smtp://user@:password@localhost:25"
   DEFAULT_FROM_EMAIL = "web@example.com"
@@ -19,7 +19,7 @@ web_environment_variables = {
   BASIC_AUTH_PASSWORD = "secret"
 }
 scrapy_image_tag = "sha-123"
-scrapy_replica_count = 3
+scrapy_replica_count = 1
 scrapy_environment_variables = {
 }
 aks_version = "1.21.9"


### PR DESCRIPTION
We changed the number of replicas from 3 to 1 to see if it was causing issues.
It was; but seemed to require two `terraform apply`s to succeed since it didn't
have a valid SCRAPY_ENDPOINT after changing scrapy's settings, so didn't touch
the web.

We figured that the example file shouldn't have a broken state.
