### PR TITLE
Fix importer-breaking bug with POST_ and PUBLICATION_SOURCES

### DIFF
--- a/importer/types/import_posts.py
+++ b/importer/types/import_posts.py
@@ -23,13 +23,13 @@ POST_SOURCES_TO_CATEGORY_SOURCES = {
     "posts-improvement-hub": "categories-improvement-hub",
     "posts-non-executive-opportunities": "categories-non-executive" "-opportunities",
     "posts-rightcare": "categories-rightcare",
-    "posts-north-east-yorkshire": "North East and Yorkshire",
-    "posts-south": "South West",
-    "posts-london": "London",
-    "posts-east-of-england": "East of England",
-    "posts-midlands": "Midlands",
-    "posts-north-west": "North West",
-    "posts-south-east": "South East",
+    "posts-north-east-yorkshire": "categories-north-east-yorkshire",
+    "posts-south": "categories-south",
+    "posts-london": "categories-london",
+    "posts-east-of-england": "categories-east-of-england",
+    "posts-midlands": "categories-midlands",
+    "posts-north-west": "categories-north-west",
+    "posts-south-east": "categories-south-west",
 }
 
 # so we can a post to a sub site and build out sub site post index pages
@@ -42,6 +42,13 @@ POST_SOURCES = {
     "posts-improvement-hub": "Improvement Hub",
     "posts-non-executive-opportunities": "Non-executive opportunities",
     "posts-rightcare": "Right Care",
+    "posts-north-east-yorkshire": "North East and Yorkshire",
+    "posts-south": "South West",
+    "posts-london": "London",
+    "posts-east-of-england": "East of England",
+    "posts-midlands": "Midlands",
+    "posts-north-west": "North West",
+    "posts-south-east": "South East",
 }
 
 

--- a/importer/types/import_publications.py
+++ b/importer/types/import_publications.py
@@ -52,6 +52,13 @@ PUBLICATION_SOURCES_TO_CATEGORY_SOURCES = {
     "publications-improvement-hub": "categories-improvement-hub",
     "publications-non-executive-opportunities": "categories-non-executive-opportunities",
     "publications-rightcare": "categories-rightcare",
+    "publications-north-east-yorkshire": "categories-north-east-yorkshire",
+    "publications-south": "categories-south",
+    "publications-london": "categories-london",
+    "publications-east-of-england": "categories-east-of-england",
+    "publications-midlands": "categories-midlands",
+    "publications-north-west": "categories-north-west",
+    "publications-south-east": "categories-south-east",
 }
 
 


### PR DESCRIPTION
There are two lists of microsites in import_posts, one with English names
(POST_SOURCES) and one with the relevant categories (POST_SOURCES_TO_CATEGORY_SOURCES).

When updating these lists, the English names were appended to the wrong list.

Additionally, they weren't added at all to the PUBLICATION_SOURCES_TO_CATEGORY_SOURCES list
(the same issue, but because the variables were in the other order, the values were correct for PUBLICATION_SOURCES)