### PR TITLE
Remove publication_type_id search index and all associated searches and tests

### DIFF
--- a/cms/publications/models.py
+++ b/cms/publications/models.py
@@ -116,7 +116,10 @@ class PublicationPublicationTypeRelationship(models.Model):
 
 class Publication(RoutablePageMixin, MetadataMixin, CategoryPage):
     search_fields = CategoryPage.search_fields + [
-        index.FilterField("publication_type_id")
+        # Not having this means we can't search on publication type.
+        # Having this produces a warning error and might be responsible for ElasticSearch crashes
+        # with an error message like https://github.com/wagtail/wagtail/issues/6483
+        # index.FilterField("publication_type_id")
     ]
 
     @route(r"^pdf/$")

--- a/cms/search/tests.py
+++ b/cms/search/tests.py
@@ -35,57 +35,59 @@ class TestPagelessQuery(TestCase):
             "&kitten=yes&repeated=yes&repeated=yes&ocelot=no",
         )
 
-class PublicationFilters(TestCase):
-    fixtures = ["fixtures/publication_types.json"]
 
-    def test_a_publication_filter(self):
-        """Publication filters include Publications that are of the right type, even if they have other types"""
-        response = self.client.get(
-            "/search/?query=e&content_type=publications&publication_type=ocelot"
-        )
-        self.assertContains(response, "Ocelot Kitten")
-        self.assertNotContains(response, "Panther Kitten")
-        self.assertNotContains(response, "Puppies")
-        self.assertContains(response, "Panthelot")
+# # Disabled this class of tests in order to see if this helps ElasticSearch
+# class PublicationFilters():
+#     fixtures = ["fixtures/publication_types.json"]
 
-    def test_no_publication_filter(self):
-        "All publications appear if there is no publication type specified"
-        response = self.client.get(
-            "/search/?query=e&content_type=publications&publication_type="
-        )
-        self.assertContains(response, "Ocelot Kitten")
-        self.assertContains(response, "Panther Kitten")
-        self.assertContains(response, "Puppies")
-        self.assertContains(response, "Panthelot")
+#     def test_a_publication_filter(self):
+#         """Publication filters include Publications that are of the right type, even if they have other types"""
+#         response = self.client.get(
+#             "/search/?query=e&content_type=publications&publication_type=ocelot"
+#         )
+#         self.assertContains(response, "Ocelot Kitten")
+#         self.assertNotContains(response, "Panther Kitten")
+#         self.assertNotContains(response, "Puppies")
+#         self.assertContains(response, "Panthelot")
 
-    def test_malformed_publication_filter(self):
-        "All publications appear if there are no valid publication types"
-        response = self.client.get(
-            "/search/?query=e&content_type=publications&publication_type=stegosaurus"
-        )
-        self.assertContains(response, "Ocelot Kitten")
-        self.assertContains(response, "Panther Kitten")
-        self.assertContains(response, "Puppies")
-        self.assertContains(response, "Panthelot")
+#     def test_no_publication_filter(self):
+#         "All publications appear if there is no publication type specified"
+#         response = self.client.get(
+#             "/search/?query=e&content_type=publications&publication_type="
+#         )
+#         self.assertContains(response, "Ocelot Kitten")
+#         self.assertContains(response, "Panther Kitten")
+#         self.assertContains(response, "Puppies")
+#         self.assertContains(response, "Panthelot")
 
-    def test_combo_publication_filter(self):
-        "Both ocelots and panthers appear if selected, but not puppies"
-        response = self.client.get(
-            "/search/?query=e&content_type=publications&publication_type=ocelot&publication_type=panther"
-        )
-        self.assertContains(response, "Ocelot Kitten")
-        self.assertContains(response, "Panther Kitten")
-        self.assertNotContains(response, "Puppies")
-        self.assertContains(response, "Panthelot")
+#     def test_malformed_publication_filter(self):
+#         "All publications appear if there are no valid publication types"
+#         response = self.client.get(
+#             "/search/?query=e&content_type=publications&publication_type=stegosaurus"
+#         )
+#         self.assertContains(response, "Ocelot Kitten")
+#         self.assertContains(response, "Panther Kitten")
+#         self.assertContains(response, "Puppies")
+#         self.assertContains(response, "Panthelot")
 
-    def test_publications_and_dates(self):
-        "Combining different search fields works correctly."
-        response = self.client.get(
-            "/search/?query=e&content_type=publications&publication_type=ocelot&before-year=2000"
-        )
-        self.assertNotContains(response, "Ocelot Kitten")
-        self.assertNotContains(response, "Panther Kitten")
-        self.assertContains(response, "Old Ocelot")
+#     def test_combo_publication_filter(self):
+#         "Both ocelots and panthers appear if selected, but not puppies"
+#         response = self.client.get(
+#             "/search/?query=e&content_type=publications&publication_type=ocelot&publication_type=panther"
+#         )
+#         self.assertContains(response, "Ocelot Kitten")
+#         self.assertContains(response, "Panther Kitten")
+#         self.assertNotContains(response, "Puppies")
+#         self.assertContains(response, "Panthelot")
+
+#     def test_publications_and_dates(self):
+#         "Combining different search fields works correctly."
+#         response = self.client.get(
+#             "/search/?query=e&content_type=publications&publication_type=ocelot&before-year=2000"
+#         )
+#         self.assertNotContains(response, "Ocelot Kitten")
+#         self.assertNotContains(response, "Panther Kitten")
+#         self.assertContains(response, "Old Ocelot")
 
 
 class TestDateHandling(TestCase):

--- a/cms/search/views.py
+++ b/cms/search/views.py
@@ -133,20 +133,23 @@ def search(request):
                 ]
             )
 
-        publication_types = []
-        for publication_slug in publication_type_slugs_to_include:
-            # Handle the case where there's multiple conflicting types by counting them all
-            publication_types.extend(
-                PublicationType.objects.filter(slug=publication_slug)
-            )
-
-        if publication_types and search_type == "publications":
-            publication_filter = Q()
-            for publication_type in publication_types:
-                publication_filter = publication_filter | Q(
-                    publication_publication_type_relationship__publication_type=publication_type
-                )
-            queryset = queryset.filter(publication_filter)
+        # Disabled publication type filtering to attempt to diagnose whether this is causing
+        # the ElasticSearch errors.
+        #
+        # publication_types = []
+        # for publication_slug in publication_type_slugs_to_include:
+        #     # Handle the case where there's multiple conflicting types by counting them all
+        #     publication_types.extend(
+        #         PublicationType.objects.filter(slug=publication_slug)
+        #     )
+        #
+        # if publication_types and search_type == "publications":
+        #     publication_filter = Q()
+        #     for publication_type in publication_types:
+        #         publication_filter = publication_filter | Q(
+        #             publication_publication_type_relationship__publication_type=publication_type
+        #         )
+        #     queryset = queryset.filter(publication_filter)
 
         return queryset.search(query_string)
 


### PR DESCRIPTION
We think this is causing a problem with Elastic Search.
This does mean we can't search by publication type but having
somewhat-functional search feels like a bonus right now.

Plus, if this works, it's useful diagnostic information.

I can't reproduce the issue locally, even when using elasticsearch
with an imported copy of the database.

https://github.com/wagtail/wagtail/issues/3728 has the same
error:

prefix = definition_model._meta.app_label.lower() + '_' + definition_model.__name__.lower() + '__'
AttributeError: 'NoneType' object has no attribute '_meta'

and looks like it's got the same conflict between "need index to
make something work" and "search_fields contains non-existent field"

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps
