### PR TITLE
Upgrade to Debian 11 "Bullseye"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use an official Python runtime based on Debian 10 "buster" as a parent image.
-FROM python:3.8.1-slim-buster as app
+# Use an official Python runtime based on Debian 11 "bullseye" as a parent image.
+FROM python:3.8.13-slim-bullseye as app
 
 # Add user that will be used in the container.
 RUN useradd wagtail
@@ -21,7 +21,7 @@ ENV PYTHONUNBUFFERED=1 \
 RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-recommends \
     build-essential \
     libpq-dev \
-    libmariadbclient-dev \
+    libmariadb-dev \
     libjpeg62-turbo-dev \
     zlib1g-dev \
     libwebp-dev \


### PR DESCRIPTION
libpango on buster is 1.42, on bullseye it's 1.46, we need at least 1.44 or to downgrade to weasyprint 52.5.
https://stackoverflow.com/a/68839522/16633550

Upgrading seemed to be the most forward-thinking approach.
