### PR TITLE
Set Timezone to allow for DST and language to British English

### DIFF
--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -151,7 +151,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "Europe/London"
 
 USE_I18N = True
 


### PR DESCRIPTION
The British English setting is just because we probably should.

(Document is about 7 minutes old)

Before:
<img width="530" alt="image" src="https://user-images.githubusercontent.com/85497046/169268365-51b3509a-9a38-4fdf-911f-0f3214a91e37.png">

After:
<img width="462" alt="image" src="https://user-images.githubusercontent.com/85497046/169268181-181a17c5-129b-4630-8c79-1d944bfc2f6f.png">
