### PR TITLE
Add back missing search styles and right align topic on search results cards

### DIFF
--- a/packages/custom-styles/_search-results.scss
+++ b/packages/custom-styles/_search-results.scss
@@ -180,3 +180,39 @@ fieldset.sort_by_nhsuk-fieldset.nhsuk-fieldset {
   margin-left:0px;
   margin-bottom:0px;
 }
+
+
+
+.nhsuk-list .nhsuk-panel.nhsei-panel-search-result {
+  margin: 0;
+  padding-left: 0;
+  padding-right: 0;
+  border-bottom: 1px solid $nhsuk-border-color;
+  position:relative;
+// search list tags
+  .search-meta, .tag_right {
+    font-size: 16px;
+  }
+  .tag_right {
+    @media (min-width:641px){
+      position: absolute;
+      right: 0;
+      bottom: 24px;
+      width: 60%;
+      text-align: right;
+    }
+    padding-top:20px;
+  }
+}
+
+.search-meta svg {
+    width: 16px;
+    height: 16px;
+    top: 2px;
+    position: relative;
+    margin: 0 5px 0 0;
+}
+
+span.post-author {
+    padding-left: 20px;
+}


### PR DESCRIPTION
## Changes in this PR
Styling got lost https://github.com/dxw/nhs-ei.website/pull/154/commits/90e02a518456a006964f9b6c8c185915ff931031#diff-98dde4aa3f2457effdb49503c5b82d2792a22b8c45f487c7f939da62280526ea
Putting back missing styles
Trello: https://trello.com/c/mf0q6oIp/374-fe-right-aline-topic-on-search-results-cards

## Screenshots of UI changes
<img width="812" alt="Screenshot 2022-05-20 at 14 20 00" src="https://user-images.githubusercontent.com/10596845/169536539-a80921e1-c58a-4f5b-9fb5-3aaf9c6a7ee9.png">
